### PR TITLE
Add Poppins font and refine hero visuals

### DIFF
--- a/syncback/app/layout.tsx
+++ b/syncback/app/layout.tsx
@@ -1,15 +1,11 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Poppins } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const poppins = Poppins({
   subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -24,9 +20,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${poppins.className} antialiased`}>
         {children}
       </body>
     </html>

--- a/syncback/app/page.tsx
+++ b/syncback/app/page.tsx
@@ -83,7 +83,7 @@ export default function Home() {
             </span>
             <div className="relative inline-block">
               <div
-                className="pointer-events-none absolute left-1/2 top-1/2 h-56 w-56 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(255,186,90,0.75),_rgba(255,214,150,0.35),_rgba(255,255,255,0)_70%)] blur-lg -z-10"
+                className="pointer-events-none absolute left-1/2 top-1/2 h-200 w-200 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(255,186,90,0.75),_rgba(255,214,150,0.35),_rgba(255,255,255,0)_70%)] "
                 aria-hidden
               />
               <h1 className="relative text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl lg:text-6xl">

--- a/syncback/app/page.tsx
+++ b/syncback/app/page.tsx
@@ -81,9 +81,15 @@ export default function Home() {
               <Sparkles className="h-4 w-4 text-sky-500" aria-hidden />
               Feedback that flows back instantly
             </span>
-            <h1 className="text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl lg:text-6xl">
-              Close the feedback loop the moment customers scan.
-            </h1>
+            <div className="relative inline-block">
+              <div
+                className="pointer-events-none absolute left-1/2 top-1/2 h-56 w-56 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(255,186,90,0.75),_rgba(255,214,150,0.35),_rgba(255,255,255,0)_70%)] blur-lg -z-10"
+                aria-hidden
+              />
+              <h1 className="relative text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl lg:text-6xl">
+                Close the feedback loop the moment customers scan with SyncBack.
+              </h1>
+            </div>
             <p className="max-w-xl text-lg text-slate-600 sm:text-xl">
               SyncBack is the QR-powered feedback lane that brings candid ratings straight to your inbox—no apps, no logins, just beautifully simple insights you can act on today.
             </p>
@@ -118,7 +124,7 @@ export default function Home() {
             </div>
           </div>
 
-          <div className="relative flex items-center justify-center">
+          <div className="relative flex flex-col items-center justify-center gap-6">
             <div className="relative h-full w-full max-w-[420px] rounded-[36px] border border-white/80 bg-white/80 p-6 shadow-xl shadow-slate-900/10 backdrop-blur">
               <div className="flex items-center justify-between rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6 text-white">
                 <div>
@@ -158,15 +164,13 @@ export default function Home() {
                 </div>
               </div>
             </div>
-            <div className="absolute -left-10 top-16 hidden rounded-3xl border border-white/70 bg-white/80 px-5 py-4 text-sm font-medium text-slate-700 shadow-lg shadow-slate-900/10 backdrop-blur sm:flex animate-float" aria-hidden>
-              <div className="flex items-center gap-2">
-                <div className="flex items-center gap-1 text-amber-400">
-                  {[...Array(5)].map((_, index) => (
-                    <Star key={`floating-${index}`} className="h-4 w-4 fill-amber-400 text-amber-400" />
-                  ))}
-                </div>
-                “Made sharing thoughts so easy!”
+            <div className="flex items-center gap-2 rounded-3xl border border-white/70 bg-white/80 px-5 py-4 text-sm font-medium text-slate-700 shadow-lg shadow-slate-900/10 backdrop-blur animate-float">
+              <div className="flex items-center gap-1 text-amber-400">
+                {[...Array(5)].map((_, index) => (
+                  <Star key={`floating-${index}`} className="h-4 w-4 fill-amber-400 text-amber-400" />
+                ))}
               </div>
+              “Made sharing thoughts so easy!”
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- replace the default font stack with the Poppins family so it applies across the site
- add a soft semicircle glow behind the hero headline and update the copy to mention SyncBack
- move the floating “Made sharing thoughts so easy!” callout beneath the New feedback card for better layout flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbd268adb4832baba048c73ecd658d