### PR TITLE
Add Clerk authentication integration

### DIFF
--- a/syncback/.gitignore
+++ b/syncback/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# clerk configuration (can include secrets)
+/.clerk/

--- a/syncback/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/syncback/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignIn } from "@clerk/nextjs";
+
+export default function SignInPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#f5f7ff] p-6">
+      <SignIn routing="path" signUpUrl="/sign-up" />
+    </div>
+  );
+}

--- a/syncback/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/syncback/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignUp } from "@clerk/nextjs";
+
+export default function SignUpPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#f5f7ff] p-6">
+      <SignUp routing="path" signInUrl="/sign-in" />
+    </div>
+  );
+}

--- a/syncback/app/providers.tsx
+++ b/syncback/app/providers.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ClerkProvider } from "@clerk/nextjs";
 import { MantineProvider } from "@mantine/core";
 import type { ReactNode } from "react";
 
@@ -8,5 +9,9 @@ type ProvidersProps = {
 };
 
 export function Providers({ children }: ProvidersProps) {
-  return <MantineProvider defaultColorScheme="light">{children}</MantineProvider>;
+  return (
+    <ClerkProvider>
+      <MantineProvider defaultColorScheme="light">{children}</MantineProvider>
+    </ClerkProvider>
+  );
 }

--- a/syncback/components/navigation/HeaderMegaMenu.tsx
+++ b/syncback/components/navigation/HeaderMegaMenu.tsx
@@ -12,7 +12,6 @@ import {
   TablerIconsProps,
 } from "@tabler/icons-react";
 import {
-  Anchor,
   Box,
   Burger,
   Button,
@@ -21,14 +20,14 @@ import {
   Divider,
   Drawer,
   Group,
-  HoverCard,
   ScrollArea,
-  SimpleGrid,
   Text,
   ThemeIcon,
   UnstyledButton,
   useMantineTheme,
 } from "@mantine/core";
+import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
+import Link from "next/link";
 import { useDisclosure } from "@mantine/hooks";
 import classes from "./HeaderMegaMenu.module.css";
 
@@ -108,15 +107,23 @@ export function HeaderMegaMenu() {
           </Group>
 
           <Group h="100%" gap={0} visibleFrom="sm">
-            <a href="#" className={classes.link}>
+            <Link href="/" className={classes.link}>
               Home
-            </a>
-           
+            </Link>
           </Group>
 
-          <Group visibleFrom="sm">
-            <Button variant="default">Log in</Button>
-            <Button>Sign up</Button>
+          <Group visibleFrom="sm" gap="sm">
+            <SignedOut>
+              <Button component={Link} href="/sign-in" variant="default">
+                Log in
+              </Button>
+              <Button component={Link} href="/sign-up">
+                Sign up
+              </Button>
+            </SignedOut>
+            <SignedIn>
+              <UserButton afterSignOutUrl="/" appearance={{ elements: { avatarBox: { width: 36, height: 36 } } }} />
+            </SignedIn>
           </Group>
 
           <Burger opened={drawerOpened} onClick={toggleDrawer} hiddenFrom="sm" />
@@ -135,9 +142,9 @@ export function HeaderMegaMenu() {
         <ScrollArea h="calc(100vh - 80px)" mx="-md">
           <Divider my="sm" />
 
-          <a href="#" className={classes.link}>
+          <Link href="/" className={classes.link}>
             Home
-          </a>
+          </Link>
           <UnstyledButton className={classes.link} onClick={toggleLinks}>
             <Center inline>
               <Box component="span" mr={5}>
@@ -156,10 +163,21 @@ export function HeaderMegaMenu() {
 
           <Divider my="sm" />
 
-          <Group justify="center" grow pb="xl" px="md">
-            <Button variant="default">Log in</Button>
-            <Button>Sign up</Button>
-          </Group>
+          <SignedOut>
+            <Group justify="center" grow pb="xl" px="md">
+              <Button component={Link} href="/sign-in" variant="default">
+                Log in
+              </Button>
+              <Button component={Link} href="/sign-up">
+                Sign up
+              </Button>
+            </Group>
+          </SignedOut>
+          <SignedIn>
+            <Group justify="center" pb="xl" px="md">
+              <UserButton afterSignOutUrl="/" />
+            </Group>
+          </SignedIn>
         </ScrollArea>
       </Drawer>
     </Box>

--- a/syncback/middleware.ts
+++ b/syncback/middleware.ts
@@ -1,0 +1,9 @@
+import { clerkMiddleware } from "@clerk/nextjs/server";
+
+export default clerkMiddleware({
+  publicRoutes: ["/", "/sign-in(.*)", "/sign-up(.*)"],
+});
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\..*).*)"],
+};


### PR DESCRIPTION
## Summary
- wrap the application providers with Clerk to enable authentication features
- implement Clerk-powered sign-in and sign-up pages and link them from the navigation
- add middleware to protect private routes and show Clerk session state in the header

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc41aaa92c832bb571f6d3d4ce6600