### PR TITLE
Add Convex schema for feedback platform

### DIFF
--- a/syncback/convex/_generated/dataModel.d.ts
+++ b/syncback/convex/_generated/dataModel.d.ts
@@ -8,29 +8,29 @@
  * @module
  */
 
-import { AnyDataModel } from "convex/server";
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
 import type { GenericId } from "convex/values";
-
-/**
- * No `schema.ts` file found!
- *
- * This generated code has permissive types like `Doc = any` because
- * Convex doesn't know your schema. If you'd like more type safety, see
- * https://docs.convex.dev/using/schemas for instructions on how to add a
- * schema file.
- *
- * After you change a schema, rerun codegen with `npx convex dev`.
- */
+import schema from "../schema.js";
 
 /**
  * The names of all of your Convex tables.
  */
-export type TableNames = string;
+export type TableNames = TableNamesInDataModel<DataModel>;
 
 /**
  * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
  */
-export type Doc = any;
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
 
 /**
  * An identifier for a document in Convex.
@@ -42,8 +42,10 @@ export type Doc = any;
  *
  * IDs are just strings at runtime, but this type can be used to distinguish them from other
  * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
  */
-export type Id<TableName extends TableNames = TableNames> =
+export type Id<TableName extends TableNames | SystemTableNames> =
   GenericId<TableName>;
 
 /**
@@ -55,4 +57,4 @@ export type Id<TableName extends TableNames = TableNames> =
  * This type is used to parameterize methods like `queryGeneric` and
  * `mutationGeneric` to make them type-safe.
  */
-export type DataModel = AnyDataModel;
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/syncback/convex/schema.ts
+++ b/syncback/convex/schema.ts
@@ -1,0 +1,55 @@
+import { defineSchema, defineTable } from "convex/schema";
+import { v } from "convex/values";
+
+export default defineSchema({
+  users: defineTable({
+    clerkUserId: v.string(),
+    email: v.string(),
+    createdAt: v.number(),
+    lastSeenAt: v.optional(v.number()),
+    organisationName: v.string(),
+    organisationID: v.string(),
+  })
+    .index("by_clerkUserId", ["clerkUserId"], { unique: true })
+    .index("by_email", ["email"])
+    .index("by_organisationID", ["organisationID"], { unique: true }),
+
+  businesses: defineTable({
+    ownerUserId: v.id("users"),
+    name: v.string(),
+    email: v.string(),
+    phone: v.string(),
+    slug: v.string(),
+    qrSvg: v.string(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_ownerUserId", ["ownerUserId"])
+    .index("by_slug", ["slug"], { unique: true }),
+
+  feedbacks: defineTable({
+    businessId: v.id("businesses"),
+    rating: v.number(),
+    message: v.string(),
+    createdAt: v.number(),
+    status: v.union(
+      v.literal("new"),
+      v.literal("seen"),
+      v.literal("archived"),
+    ),
+    source: v.optional(
+      v.union(v.literal("qr"), v.literal("link"), v.literal("kiosk")),
+    ),
+    ipHash: v.optional(v.string()),
+  })
+    .index("by_businessId", ["businessId"])
+    .index("by_businessId_createdAt", ["businessId", "createdAt"]),
+
+  aggregates_daily: defineTable({
+    businessId: v.id("businesses"),
+    date: v.string(),
+    count: v.number(),
+    avgRating: v.number(),
+    createdAt: v.number(),
+  }).index("by_businessId_date", ["businessId", "date"], { unique: true }),
+});


### PR DESCRIPTION
## Summary
- define Convex schema covering users, businesses, feedbacks, and aggregates
- add indexes and relationships needed for feedback workflow
- refresh generated data model types to use the new schema

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc4e38f908832b9094def9d171e2ac