### PR TITLE
Fix Convex schema import and Mantine hydration attribute

### DIFF
--- a/syncback/app/layout.tsx
+++ b/syncback/app/layout.tsx
@@ -23,9 +23,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" data-mantine-color-scheme="light">
       <head>
-        <ColorSchemeScript />
+        <ColorSchemeScript defaultColorScheme="light" />
       </head>
       <body className={`${poppins.className} antialiased`}>
         <Providers>{children}</Providers>

--- a/syncback/convex/schema.ts
+++ b/syncback/convex/schema.ts
@@ -1,4 +1,4 @@
-import { defineSchema, defineTable } from "convex/schema";
+import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
 export default defineSchema({


### PR DESCRIPTION
## Summary
- update the Convex schema to import utilities from the supported `convex/server` entry point so TypeScript can resolve the module
- set the Mantine color scheme defaults on the root html element to avoid hydration attribute mismatches

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc4fca16e8832b9a7e238ec53deaf1