### PR TITLE
Redirect new signups to settings page

### DIFF
--- a/syncback/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/syncback/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -3,7 +3,11 @@ import { SignUp } from "@clerk/nextjs";
 export default function SignUpPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-[#f5f7ff] p-6">
-      <SignUp routing="path" signInUrl="/sign-in" />
+      <SignUp
+        routing="path"
+        signInUrl="/sign-in"
+        afterSignUpUrl="/settings"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- redirect the Clerk sign-up flow to the settings page so new accounts can fill in company info and generate their QR code

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc5305b844832b89674ad48c28361b