### PR TITLE
feat: build QR-enabled business settings experience

### DIFF
--- a/syncback/app/(dashboard)/settings/actions.ts
+++ b/syncback/app/(dashboard)/settings/actions.ts
@@ -1,0 +1,115 @@
+"use server";
+
+import { randomUUID } from "node:crypto";
+
+import { headers } from "next/headers";
+import { currentUser } from "@clerk/nextjs/server";
+
+import { api } from "@/convex/_generated/api";
+import { getConvexClient } from "@/lib/convexClient";
+
+export type SettingsFormState = {
+  status: "idle" | "success" | "error";
+  message?: string;
+  businessId?: string;
+  slug?: string;
+  qrSvg?: string;
+  feedbackUrl?: string;
+  name?: string;
+  email?: string;
+};
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function baseSlug(input: string) {
+  const normalized = input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+
+  if (normalized.length === 0) {
+    return "business";
+  }
+
+  return normalized;
+}
+
+export async function resolveAppUrl() {
+  const envUrl =
+    process.env.NEXT_PUBLIC_APP_URL ??
+    process.env.APP_URL ??
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null);
+
+  if (envUrl) {
+    return envUrl.replace(/\/$/, "");
+  }
+
+  const headerList = headers();
+  const host = headerList.get("host");
+  if (host) {
+    const protocol = headerList.get("x-forwarded-proto") ?? "https";
+    return `${protocol}://${host}`;
+  }
+
+  return "http://localhost:3000";
+}
+
+export async function saveBusiness(
+  _prevState: SettingsFormState,
+  formData: FormData,
+): Promise<SettingsFormState> {
+  const user = await currentUser();
+
+  if (!user) {
+    return {
+      status: "error",
+      message: "You need to be signed in to update your business settings.",
+    };
+  }
+
+  const name = (formData.get("name") ?? "").toString().trim();
+  const email = (formData.get("email") ?? "").toString().trim();
+  const existingSlug = (formData.get("slug") ?? "").toString().trim();
+
+  if (!name) {
+    return { status: "error", message: "Add your business name to continue." };
+  }
+
+  if (!email || !emailRegex.test(email)) {
+    return {
+      status: "error",
+      message: "Enter a valid email so we know where to send new feedback.",
+    };
+  }
+
+  const slug = existingSlug || `${baseSlug(name)}-${randomUUID().slice(0, 6)}`;
+  const appUrl = await resolveAppUrl();
+
+  const convex = getConvexClient();
+  const ensuredUserId = await convex.mutation(api.users.ensure, {
+    clerkUserId: user.id,
+    email,
+    organisationName: name,
+    organisationID: slug,
+  });
+
+  const result = await convex.mutation(api.businesses.save, {
+    ownerUserId: ensuredUserId,
+    name,
+    email,
+    slug,
+    appUrl,
+  });
+
+  return {
+    status: "success",
+    message: "Settings updated. Print or share your new QR code!",
+    businessId: result.businessId,
+    slug: result.slug,
+    qrSvg: result.qrSvg,
+    feedbackUrl: result.feedbackUrl ?? `${appUrl}/${result.slug}/feedback`,
+    name,
+    email,
+  };
+}

--- a/syncback/app/(dashboard)/settings/page.tsx
+++ b/syncback/app/(dashboard)/settings/page.tsx
@@ -1,0 +1,134 @@
+import { currentUser } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import {
+  BadgeCheck,
+  MailCheck,
+  QrCode,
+  Sparkles,
+} from "lucide-react";
+
+import { api } from "@/convex/_generated/api";
+import { HeaderMegaMenu } from "@/components/navigation/HeaderMegaMenu";
+import { getConvexClient } from "@/lib/convexClient";
+
+import { SettingsForm } from "./settings-form";
+import { resolveAppUrl, type SettingsFormState } from "./actions";
+
+const highlights = [
+  {
+    icon: Sparkles,
+    title: "Brand-ready in minutes",
+    description:
+      "Your QR card pulls through your business name and routes guests to a polished form.",
+  },
+  {
+    icon: MailCheck,
+    title: "Instant inbox alerts",
+    description:
+      "Every response lands in the inbox you specify so you can act before issues snowball.",
+  },
+  {
+    icon: BadgeCheck,
+    title: "Anonymous & honest",
+    description:
+      "Guests don't need to log in—just scan, rate, and send feedback straight to you.",
+  },
+];
+
+export default async function SettingsPage() {
+  const user = await currentUser();
+
+  if (!user) {
+    redirect("/sign-in");
+  }
+
+  const convex = getConvexClient();
+  const appUrl = await resolveAppUrl();
+
+  const business = await convex
+    .query(api.businesses.forClerkUser, {
+      clerkUserId: user.id,
+      appUrl,
+    })
+    .catch(() => null);
+
+  const defaultEmail = user.primaryEmailAddress?.emailAddress ?? "";
+
+  const initialState: SettingsFormState = {
+    status: "idle",
+    businessId: business?._id,
+    name: business?.name ?? "",
+    email: business?.email ?? defaultEmail,
+    slug: business?.slug ?? "",
+    qrSvg: business?.qrSvg ?? undefined,
+    feedbackUrl:
+      business?.feedbackUrl ??
+      (business?.slug ? `${appUrl.replace(/\/$/, "")}/${business.slug}/feedback` : undefined),
+  };
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950">
+      <HeaderMegaMenu />
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute left-1/2 top-[-8%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(59,130,246,0.22),_rgba(255,255,255,0))] blur-3xl" />
+        <div className="absolute right-[8%] top-[24%] h-60 w-60 rounded-full bg-[radial-gradient(circle_at_center,_rgba(244,114,182,0.3),_rgba(255,255,255,0))] blur-3xl" />
+        <div className="absolute left-[12%] bottom-[20%] h-64 w-64 rounded-full bg-[radial-gradient(circle_at_center,_rgba(34,197,94,0.26),_rgba(255,255,255,0))] blur-3xl" />
+        <div className="absolute inset-0 bg-grid-soft opacity-40" />
+        <div className="absolute inset-0 bg-noise opacity-40 mix-blend-soft-light" />
+      </div>
+
+      <main className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-6 pb-24 pt-20 sm:px-8 lg:px-12">
+        <section className="grid gap-10 lg:grid-cols-[minmax(0,_1.05fr)_minmax(0,_0.95fr)] lg:items-center">
+          <div className="space-y-7">
+            <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm backdrop-blur">
+              <Sparkles className="h-4 w-4 text-sky-500" aria-hidden />
+              Craft your feedback hub
+            </span>
+            <div className="space-y-4">
+              <h1 className="text-3xl font-semibold leading-tight text-slate-950 sm:text-4xl lg:text-5xl">
+                Set up a beautiful QR-powered page for collecting guest feedback
+              </h1>
+              <p className="max-w-xl text-base text-slate-600 sm:text-lg">
+                Add your business details once and we&rsquo;ll generate a shareable QR card plus a magic link that guides every guest back to your private feedback form.
+              </p>
+            </div>
+
+            <ul className="grid gap-4 sm:grid-cols-2">
+              {highlights.map(({ icon: Icon, title, description }) => (
+                <li key={title} className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-lg">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-sky-500/10 text-sky-600">
+                      <Icon className="h-5 w-5" aria-hidden />
+                    </div>
+                    <h3 className="text-base font-semibold text-slate-900">{title}</h3>
+                  </div>
+                  <p className="mt-3 text-sm text-slate-600">{description}</p>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="relative order-first flex items-center justify-center lg:order-last">
+            <div className="relative w-full max-w-md rounded-[32px] border border-white/70 bg-white/70 p-8 shadow-xl backdrop-blur">
+              <div className="absolute -left-6 top-8 hidden h-20 w-20 rounded-full bg-gradient-to-br from-sky-400/40 to-blue-500/10 blur-xl lg:block" />
+              <div className="absolute -right-6 bottom-8 hidden h-24 w-24 rounded-full bg-gradient-to-br from-emerald-400/40 to-emerald-500/10 blur-xl lg:block" />
+              <div className="relative flex flex-col items-center gap-5 text-center">
+                <div className="rounded-full bg-sky-500/10 p-3 text-sky-600">
+                  <QrCode className="h-6 w-6" aria-hidden />
+                </div>
+                <h2 className="text-xl font-semibold text-slate-900">
+                  Drop your details, receive a branded QR card
+                </h2>
+                <p className="text-sm text-slate-600">
+                  Perfect for tabletops, checkout counters, event lanyards—wherever your guests linger.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <SettingsForm initialState={initialState} />
+      </main>
+    </div>
+  );
+}

--- a/syncback/app/(dashboard)/settings/settings-form.tsx
+++ b/syncback/app/(dashboard)/settings/settings-form.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useFormState, useFormStatus } from "react-dom";
+import {
+  ArrowRight,
+  CheckCircle2,
+  Copy,
+  Download,
+  Loader2,
+  Mail,
+  QrCode,
+  Sparkles,
+  XCircle,
+} from "lucide-react";
+
+import { saveBusiness, type SettingsFormState } from "./actions";
+
+type SettingsFormProps = {
+  initialState: SettingsFormState;
+};
+
+const fallbackState: SettingsFormState = {
+  status: "idle",
+};
+
+export function SettingsForm({ initialState }: SettingsFormProps) {
+  const [state, formAction] = useFormState(saveBusiness, initialState ?? fallbackState);
+  const [copied, setCopied] = useState(false);
+  const [downloaded, setDownloaded] = useState(false);
+
+  const currentState = state ?? fallbackState;
+  const currentName = currentState.name ?? initialState.name ?? "";
+  const currentEmail = currentState.email ?? initialState.email ?? "";
+  const currentSlug = currentState.slug ?? initialState.slug ?? "";
+  const currentQrSvg = currentState.qrSvg ?? initialState.qrSvg;
+  const currentFeedbackUrl = currentState.feedbackUrl ?? initialState.feedbackUrl;
+
+  useEffect(() => {
+    if (!copied && !downloaded) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setCopied(false);
+      setDownloaded(false);
+    }, 2200);
+
+    return () => window.clearTimeout(timeout);
+  }, [copied, downloaded]);
+
+  async function handleCopyLink() {
+    if (!currentFeedbackUrl) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(currentFeedbackUrl);
+      setCopied(true);
+    } catch (error) {
+      console.error("Failed to copy link", error);
+    }
+  }
+
+  function handleDownload() {
+    if (!currentQrSvg) {
+      return;
+    }
+
+    try {
+      const blob = new Blob([currentQrSvg], { type: "image/svg+xml;charset=utf-8" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `${currentSlug || "syncback-qr"}.svg`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+      setDownloaded(true);
+    } catch (error) {
+      console.error("Failed to download QR code", error);
+    }
+  }
+
+  return (
+    <section className="relative isolate overflow-hidden rounded-[36px] border border-white/70 bg-white/90 p-6 shadow-2xl backdrop-blur sm:p-10">
+      <div className="absolute -left-12 top-16 h-32 w-32 rounded-full bg-gradient-to-br from-sky-400/30 to-blue-500/10 blur-3xl" />
+      <div className="absolute -right-14 bottom-20 h-36 w-36 rounded-full bg-gradient-to-tr from-emerald-400/30 to-emerald-500/10 blur-3xl" />
+      <div className="relative grid gap-10 lg:grid-cols-[minmax(0,_1fr)_minmax(0,_0.85fr)] lg:items-start">
+        <div className="space-y-8">
+          <header className="space-y-3">
+            <span className="inline-flex items-center gap-2 rounded-full bg-sky-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-600">
+              <Sparkles className="h-3.5 w-3.5" aria-hidden />
+              Guided setup
+            </span>
+            <h2 className="text-2xl font-semibold text-slate-950 sm:text-3xl">
+              Tell us who you are and where to send glowing reviews
+            </h2>
+            <p className="text-sm leading-relaxed text-slate-600 sm:text-base">
+              Once saved we lock in your unique link, render a crisp QR code, and email every new response to the inbox you choose.
+            </p>
+          </header>
+
+          {currentState.status === "success" && currentState.message ? (
+            <div className="flex items-center gap-3 rounded-2xl border border-emerald-200 bg-emerald-50/80 p-4 text-emerald-700">
+              <CheckCircle2 className="h-5 w-5 flex-shrink-0" aria-hidden />
+              <p className="text-sm font-medium">{currentState.message}</p>
+            </div>
+          ) : currentState.status === "error" && currentState.message ? (
+            <div className="flex items-center gap-3 rounded-2xl border border-rose-200 bg-rose-50/80 p-4 text-rose-600">
+              <XCircle className="h-5 w-5 flex-shrink-0" aria-hidden />
+              <p className="text-sm font-medium">{currentState.message}</p>
+            </div>
+          ) : null}
+
+          <form action={formAction} className="space-y-7">
+            <input type="hidden" name="slug" value={currentSlug} />
+
+            <div className="space-y-2">
+              <label htmlFor="name" className="block text-sm font-semibold text-slate-900">
+                Business name
+              </label>
+              <input
+                id="name"
+                name="name"
+                type="text"
+                placeholder="Ex. Wildflower Café"
+                defaultValue={currentName}
+                className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-sky-400 focus:ring-2 focus:ring-sky-200"
+                required
+              />
+              <p className="text-xs text-slate-500">
+                We&rsquo;ll use this to personalise your QR card and public feedback page.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="email" className="block text-sm font-semibold text-slate-900">
+                Notification email
+              </label>
+              <div className="relative">
+                <div className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-slate-400">
+                  <Mail className="h-4 w-4" aria-hidden />
+                </div>
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  placeholder="hello@yourbusiness.com"
+                  defaultValue={currentEmail}
+                  className="w-full rounded-2xl border border-slate-200 bg-white px-10 py-3 text-base text-slate-900 shadow-sm outline-none transition focus:border-sky-400 focus:ring-2 focus:ring-sky-200"
+                  required
+                />
+              </div>
+              <p className="text-xs text-slate-500">
+                We&rsquo;ll send new feedback alerts here instantly.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-slate-600">
+                You&rsquo;ll be able to refresh your QR any time after saving.
+              </p>
+              <SubmitButton />
+            </div>
+          </form>
+        </div>
+
+        <div className="relative overflow-hidden rounded-[28px] border border-slate-100 bg-slate-50/80 p-6 shadow-inner">
+          <div className="absolute -top-12 left-16 h-32 w-32 rounded-full bg-sky-400/20 blur-3xl" />
+          <div className="absolute -bottom-14 right-6 h-28 w-28 rounded-full bg-emerald-400/20 blur-3xl" />
+          <div className="relative flex flex-col gap-6">
+            <div className="rounded-3xl bg-white/90 p-6 shadow-lg">
+              <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+                Your QR preview
+              </p>
+              <div className="mt-4 flex flex-col items-center justify-center gap-4">
+                <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+                  {currentQrSvg ? (
+                    <div
+                      className="h-44 w-44"
+                      aria-label="Generated QR code"
+                      dangerouslySetInnerHTML={{ __html: currentQrSvg }}
+                    />
+                  ) : (
+                    <div className="flex h-44 w-44 flex-col items-center justify-center gap-2 text-center text-slate-400">
+                      <QrCode className="h-8 w-8" aria-hidden />
+                      <p className="text-xs font-medium">Save to generate your QR</p>
+                    </div>
+                  )}
+                </div>
+                <div className="flex flex-wrap items-center justify-center gap-3">
+                  <button
+                    type="button"
+                    onClick={handleDownload}
+                    disabled={!currentQrSvg}
+                    className="inline-flex items-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-md transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400/60"
+                  >
+                    <Download className="h-4 w-4" aria-hidden />
+                    {downloaded ? "Saved!" : "Download SVG"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleCopyLink}
+                    disabled={!currentFeedbackUrl}
+                    className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-sky-400 hover:text-sky-600 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+                  >
+                    <Copy className="h-4 w-4" aria-hidden />
+                    {copied ? "Link copied" : "Copy feedback link"}
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm">
+              <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+                Live link
+              </p>
+              <p className="mt-2 break-all text-sm font-medium text-slate-900">
+                {currentFeedbackUrl ?? "Your link will appear here after saving"}
+              </p>
+              <p className="mt-3 text-xs text-slate-500">
+                Share this link on receipts, emails, or digital signage to collect feedback without the QR.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      className="inline-flex items-center gap-2 rounded-full bg-sky-500 px-5 py-2.5 text-sm font-semibold text-white shadow-lg transition hover:bg-sky-600 focus:outline-none focus:ring-2 focus:ring-sky-200 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-sky-300"
+      disabled={pending}
+    >
+      {pending ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : <ArrowRight className="h-4 w-4" aria-hidden />}
+      {pending ? "Saving" : "Save & generate QR"}
+    </button>
+  );
+}

--- a/syncback/convex/businesses.ts
+++ b/syncback/convex/businesses.ts
@@ -1,0 +1,108 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import QRCode from "qrcode-generator";
+
+export const save = mutation({
+  args: {
+    ownerUserId: v.id("users"),
+    name: v.string(),
+    email: v.string(),
+    slug: v.string(),
+    appUrl: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("businesses")
+      .withIndex("by_ownerUserId", (q) => q.eq("ownerUserId", args.ownerUserId))
+      .unique();
+
+    const timestamp = Date.now();
+    const baseSlug = args.slug;
+    let slug = baseSlug;
+    let collisionCount = 0;
+
+    // ensure slug uniqueness unless it belongs to the existing business
+    while (true) {
+      const collision = await ctx.db
+        .query("businesses")
+        .withIndex("by_slug", (q) => q.eq("slug", slug))
+        .unique();
+
+      if (!collision || (existing && collision._id === existing._id)) {
+        break;
+      }
+
+      collisionCount += 1;
+      slug = `${baseSlug}-${collisionCount}`;
+    }
+
+    const normalizedBaseUrl = args.appUrl.replace(/\/$/, "");
+    const feedbackUrl = `${normalizedBaseUrl}/${slug}/feedback`;
+    const qr = QRCode(0, "M");
+    qr.addData(feedbackUrl);
+    qr.make();
+    const rawSvg = qr.createSvgTag({ scalable: true, margin: 2 });
+    const qrSvg = rawSvg.replace(/fill="#000000"/g, 'fill="#0f172a"');
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        name: args.name,
+        email: args.email,
+        slug,
+        qrSvg,
+        updatedAt: timestamp,
+      });
+      return { businessId: existing._id, slug, qrSvg, feedbackUrl };
+    }
+
+    const insertedId = await ctx.db.insert("businesses", {
+      ownerUserId: args.ownerUserId,
+      name: args.name,
+      email: args.email,
+      phone: "",
+      slug,
+      qrSvg,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    return { businessId: insertedId, slug, qrSvg, feedbackUrl };
+  },
+});
+
+export const forClerkUser = query({
+  args: { clerkUserId: v.string(), appUrl: v.optional(v.string()) },
+  handler: async (ctx, args) => {
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_clerkUserId", (q) => q.eq("clerkUserId", args.clerkUserId))
+      .unique();
+
+    if (!user) {
+      return null;
+    }
+
+    const business = await ctx.db
+      .query("businesses")
+      .withIndex("by_ownerUserId", (q) => q.eq("ownerUserId", user._id))
+      .unique();
+
+    if (!business) {
+      return null;
+    }
+
+    const baseUrl = args.appUrl ? args.appUrl.replace(/\/$/, "") : null;
+    const feedbackUrl = baseUrl ? `${baseUrl}/${business.slug}/feedback` : null;
+
+    return {
+      _id: business._id,
+      name: business.name,
+      email: business.email,
+      slug: business.slug,
+      qrSvg: business.qrSvg,
+      feedbackUrl,
+      createdAt: business.createdAt,
+      updatedAt: business.updatedAt,
+    };
+  },
+});

--- a/syncback/convex/users.ts
+++ b/syncback/convex/users.ts
@@ -1,0 +1,62 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const ensure = mutation({
+  args: {
+    clerkUserId: v.string(),
+    email: v.string(),
+    organisationName: v.string(),
+    organisationID: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("users")
+      .withIndex("by_clerkUserId", (q) => q.eq("clerkUserId", args.clerkUserId))
+      .unique();
+
+    const timestamp = Date.now();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        email: args.email,
+        organisationName: args.organisationName,
+        organisationID: args.organisationID,
+        lastSeenAt: timestamp,
+      });
+
+      return existing._id;
+    }
+
+    return await ctx.db.insert("users", {
+      clerkUserId: args.clerkUserId,
+      email: args.email,
+      organisationName: args.organisationName,
+      organisationID: args.organisationID,
+      createdAt: timestamp,
+      lastSeenAt: timestamp,
+    });
+  },
+});
+
+export const byClerkId = query({
+  args: { clerkUserId: v.string() },
+  handler: async (ctx, args) => {
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_clerkUserId", (q) => q.eq("clerkUserId", args.clerkUserId))
+      .unique();
+
+    if (!user) {
+      return null;
+    }
+
+    return {
+      _id: user._id,
+      email: user.email,
+      organisationName: user.organisationName,
+      organisationID: user.organisationID,
+      createdAt: user.createdAt,
+      lastSeenAt: user.lastSeenAt ?? null,
+    };
+  },
+});

--- a/syncback/lib/convexClient.ts
+++ b/syncback/lib/convexClient.ts
@@ -1,0 +1,28 @@
+import { ConvexHttpClient } from "convex/browser";
+
+let client: ConvexHttpClient | null = null;
+
+function resolveConvexUrl() {
+  const url =
+    process.env.CONVEX_URL ??
+    process.env.NEXT_PUBLIC_CONVEX_URL ??
+    null;
+
+  if (!url) {
+    throw new Error(
+      "Convex URL is not configured. Set CONVEX_URL or NEXT_PUBLIC_CONVEX_URL in the environment.",
+    );
+  }
+
+  return url;
+}
+
+export function getConvexClient() {
+  if (client) {
+    return client;
+  }
+
+  const url = resolveConvexUrl();
+  client = new ConvexHttpClient(url);
+  return client;
+}

--- a/syncback/package-lock.json
+++ b/syncback/package-lock.json
@@ -19,6 +19,7 @@
         "gsap": "^3.13.0",
         "lucide-react": "^0.544.0",
         "next": "15.5.4",
+        "qrcode-generator": "^1.4.4",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "tailwind-merge": "^3.3.1"
@@ -5845,6 +5846,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/qrcode-generator": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.4.4.tgz",
+      "integrity": "sha512-HM7yY8O2ilqhmULxGMpcHSF1EhJJ9yBj8gvDEuZ6M+KGJ0YY2hKpnXvRD+hZPLrDVck3ExIGhmPtSdcjC+guuw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/syncback/package.json
+++ b/syncback/package.json
@@ -19,6 +19,7 @@
     "convex": "^1.27.3",
     "gsap": "^3.13.0",
     "lucide-react": "^0.544.0",
+    "qrcode-generator": "^1.4.4",
     "next": "15.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
## Summary
- craft a mobile-first settings experience with marketing hero, highlights, and a guided form for business details and QR preview
- save business metadata through a server action that ensures Convex user records, generates QR codes, and returns shareable feedback links
- add Convex helpers and the `qrcode-generator` dependency to support QR creation and data access on the dashboard

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc564c2988832b84b827ee3b800a6c