### PR TITLE
Fix settings form action state and server QR generation

### DIFF
--- a/syncback/app/(dashboard)/settings/settings-form.tsx
+++ b/syncback/app/(dashboard)/settings/settings-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useFormState, useFormStatus } from "react-dom";
+import { useActionState, useEffect, useState } from "react";
+import { useFormStatus } from "react-dom";
 import {
   ArrowRight,
   CheckCircle2,
@@ -25,7 +25,7 @@ const fallbackState: SettingsFormState = {
 };
 
 export function SettingsForm({ initialState }: SettingsFormProps) {
-  const [state, formAction] = useFormState(saveBusiness, initialState ?? fallbackState);
+  const [state, formAction] = useActionState(saveBusiness, initialState ?? fallbackState);
   const [copied, setCopied] = useState(false);
   const [downloaded, setDownloaded] = useState(false);
 

--- a/syncback/convex/_generated/api.d.ts
+++ b/syncback/convex/_generated/api.d.ts
@@ -13,6 +13,8 @@ import type {
   FilterApi,
   FunctionReference,
 } from "convex/server";
+import type * as businesses from "../businesses.js";
+import type * as users from "../users.js";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -22,7 +24,10 @@ import type {
  * const myFunctionReference = api.myModule.myFunction;
  * ```
  */
-declare const fullApi: ApiFromModules<{}>;
+declare const fullApi: ApiFromModules<{
+  businesses: typeof businesses;
+  users: typeof users;
+}>;
 export declare const api: FilterApi<
   typeof fullApi,
   FunctionReference<any, "public">

--- a/syncback/convex/businesses.ts
+++ b/syncback/convex/businesses.ts
@@ -1,6 +1,5 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
-import QRCode from "qrcode-generator";
 
 export const save = mutation({
   args: {
@@ -9,6 +8,7 @@ export const save = mutation({
     email: v.string(),
     slug: v.string(),
     appUrl: v.string(),
+    qrSvg: v.string(),
   },
   handler: async (ctx, args) => {
     const existing = await ctx.db
@@ -38,21 +38,16 @@ export const save = mutation({
 
     const normalizedBaseUrl = args.appUrl.replace(/\/$/, "");
     const feedbackUrl = `${normalizedBaseUrl}/${slug}/feedback`;
-    const qr = QRCode(0, "M");
-    qr.addData(feedbackUrl);
-    qr.make();
-    const rawSvg = qr.createSvgTag({ scalable: true, margin: 2 });
-    const qrSvg = rawSvg.replace(/fill="#000000"/g, 'fill="#0f172a"');
 
     if (existing) {
       await ctx.db.patch(existing._id, {
         name: args.name,
         email: args.email,
         slug,
-        qrSvg,
+        qrSvg: args.qrSvg,
         updatedAt: timestamp,
       });
-      return { businessId: existing._id, slug, qrSvg, feedbackUrl };
+      return { businessId: existing._id, slug, qrSvg: args.qrSvg, feedbackUrl };
     }
 
     const insertedId = await ctx.db.insert("businesses", {
@@ -61,12 +56,12 @@ export const save = mutation({
       email: args.email,
       phone: "",
       slug,
-      qrSvg,
+      qrSvg: args.qrSvg,
       createdAt: timestamp,
       updatedAt: timestamp,
     });
 
-    return { businessId: insertedId, slug, qrSvg, feedbackUrl };
+    return { businessId: insertedId, slug, qrSvg: args.qrSvg, feedbackUrl };
   },
 });
 


### PR DESCRIPTION
## Summary
- update the settings form to use React's `useActionState` instead of the deprecated `useFormState`
- generate QR codes inside the settings server action and pass the SVG to Convex
- adjust the Convex business mutation signature and regenerate the API helper types

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcf7a6c994832b870d7d4c04ab0f3f