### PR TITLE
Add recent ratings area chart to dashboard

### DIFF
--- a/syncback/app/(dashboard)/dashboard/page.tsx
+++ b/syncback/app/(dashboard)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { HeaderMegaMenu } from "@/components/navigation/HeaderMegaMenu";
 import { StatsGrid } from "@/components/dashboard/StatsGrid";
 import { RatingTrendChart } from "@/components/dashboard/RatingTrendChart";
 import { RatingDistributionChart } from "@/components/dashboard/RatingDistributionChart";
+import { RecentRatingsAreaChart } from "@/components/dashboard/RecentRatingsAreaChart";
 import { api } from "@/convex/_generated/api";
 import { getConvexClient } from "@/lib/convexClient";
 
@@ -24,6 +25,27 @@ const ratingDistribution = [
   { segment: "3 Stars", value: 8 },
   { segment: "2 Stars", value: 4 },
   { segment: "1 Star", value: 2 },
+];
+
+const recentRatings = [
+  { rating: 4.9, receivedAt: "2024-09-19T13:32:00Z" },
+  { rating: 4.8, receivedAt: "2024-09-21T09:14:00Z" },
+  { rating: 5, receivedAt: "2024-09-22T16:05:00Z" },
+  { rating: 4.6, receivedAt: "2024-09-23T11:47:00Z" },
+  { rating: 4.7, receivedAt: "2024-09-24T18:22:00Z" },
+  { rating: 4.5, receivedAt: "2024-09-25T20:41:00Z" },
+  { rating: 4.8, receivedAt: "2024-09-26T08:03:00Z" },
+  { rating: 4.9, receivedAt: "2024-09-27T12:18:00Z" },
+  { rating: 4.4, receivedAt: "2024-09-28T15:55:00Z" },
+  { rating: 4.7, receivedAt: "2024-09-29T10:29:00Z" },
+  { rating: 4.9, receivedAt: "2024-09-30T14:36:00Z" },
+  { rating: 5, receivedAt: "2024-10-01T09:22:00Z" },
+  { rating: 4.8, receivedAt: "2024-10-02T17:11:00Z" },
+  { rating: 4.6, receivedAt: "2024-10-03T11:58:00Z" },
+  { rating: 4.7, receivedAt: "2024-10-04T19:37:00Z" },
+  { rating: 4.9, receivedAt: "2024-10-05T13:06:00Z" },
+  { rating: 4.8, receivedAt: "2024-10-06T08:44:00Z" },
+  { rating: 5, receivedAt: "2024-10-07T15:23:00Z" },
 ];
 
 export default async function DashboardPage() {
@@ -102,6 +124,21 @@ export default async function DashboardPage() {
             </div>
             <div className="mt-8 h-72 w-full">
               <RatingDistributionChart data={ratingDistribution} />
+            </div>
+          </div>
+
+          <div className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl lg:col-span-2">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-xl font-semibold text-slate-900">Recent ratings</h2>
+                <p className="text-sm text-slate-500">Explore the most recent feedback and spot shifts instantly</p>
+              </div>
+              <span className="inline-flex items-center rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-600">
+                {recentRatings.length} total ratings
+              </span>
+            </div>
+            <div className="mt-8">
+              <RecentRatingsAreaChart ratings={recentRatings} />
             </div>
           </div>
         </section>

--- a/syncback/components/dashboard/RecentRatingsAreaChart.tsx
+++ b/syncback/components/dashboard/RecentRatingsAreaChart.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { CSSProperties } from "react";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+
+type RecentRating = {
+  rating: number;
+  receivedAt: string;
+};
+
+type RecentRatingsAreaChartProps = {
+  ratings: RecentRating[];
+  minimumWindow?: number;
+};
+
+const tooltipStyles: CSSProperties = {
+  backgroundColor: "rgba(15, 23, 42, 0.9)",
+  border: "none",
+  borderRadius: "16px",
+  color: "white",
+  boxShadow: "0 20px 40px rgba(15, 23, 42, 0.25)",
+  padding: "12px 16px",
+};
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+export function RecentRatingsAreaChart({
+  ratings,
+  minimumWindow = 5,
+}: RecentRatingsAreaChartProps) {
+  const totalRatings = ratings.length;
+
+  const hasRatings = totalRatings > 0;
+  const sliderMax = hasRatings ? totalRatings : minimumWindow;
+  const sliderMin = hasRatings ? Math.min(minimumWindow, sliderMax) : minimumWindow;
+
+  const [windowSize, setWindowSize] = useState(() =>
+    Math.max(sliderMin, Math.min(sliderMax, minimumWindow)),
+  );
+
+  useEffect(() => {
+    setWindowSize((current) => {
+      if (current < sliderMin) {
+        return sliderMin;
+      }
+      if (current > sliderMax) {
+        return sliderMax;
+      }
+      return current;
+    });
+  }, [sliderMax, sliderMin]);
+
+  const ticks = useMemo(() => {
+    if (sliderMax === sliderMin) {
+      return [sliderMax];
+    }
+    return Array.from({ length: sliderMax - sliderMin + 1 }, (_, index) => sliderMin + index);
+  }, [sliderMax, sliderMin]);
+
+  const skipInterval = useMemo(() => {
+    if (ticks.length <= 6) {
+      return 1;
+    }
+    return Math.ceil(ticks.length / 6);
+  }, [ticks.length]);
+
+  const visibleRatings = useMemo(() => {
+    const count = Math.min(windowSize, sliderMax);
+    return ratings.slice(sliderMax - count);
+  }, [ratings, sliderMax, windowSize]);
+
+  const chartData = useMemo(
+    () =>
+      visibleRatings.map((entry) => ({
+        label: dateFormatter.format(new Date(entry.receivedAt)),
+        rating: entry.rating,
+      })),
+    [visibleRatings],
+  );
+
+  const averageRating = useMemo(() => {
+    if (visibleRatings.length === 0) {
+      return 0;
+    }
+    const total = visibleRatings.reduce((sum, entry) => sum + entry.rating, 0);
+    return total / visibleRatings.length;
+  }, [visibleRatings]);
+
+  if (!hasRatings) {
+    return (
+      <div className="flex h-full min-h-[18rem] flex-col items-center justify-center rounded-[32px] border border-dashed border-slate-200 bg-white/70 p-8 text-center text-sm text-slate-500">
+        <p>No ratings have been collected yet. Share your feedback link to start seeing momentum here.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-8">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="ratings-window" className="flex items-center justify-between text-slate-700">
+          <span>Last {windowSize} ratings</span>
+          <span className="text-xs font-medium text-slate-400">Average {averageRating.toFixed(2)} ★</span>
+        </Label>
+        <div>
+          <Slider
+            id="ratings-window"
+            min={sliderMin}
+            max={sliderMax}
+            value={[windowSize]}
+            onValueChange={([value]) =>
+              setWindowSize(Math.max(sliderMin, Math.min(sliderMax, value)))
+            }
+            aria-label="Select the number of recent ratings to display"
+          />
+          <span
+            className="mt-3 flex w-full items-center justify-between gap-1 px-2.5 text-xs font-medium text-slate-400"
+            aria-hidden="true"
+          >
+            {ticks.map((tick, index) => {
+              const showLabel =
+                index % skipInterval === 0 || index === 0 || index === ticks.length - 1;
+              return (
+                <span key={tick} className="flex w-0 flex-col items-center justify-center gap-2">
+                  <span
+                    className={cn(
+                      "bg-slate-400/70 h-1 w-px",
+                      !showLabel && "h-0.5",
+                    )}
+                  />
+                  <span className={cn(!showLabel && "opacity-0")}>{tick}</span>
+                </span>
+              );
+            })}
+          </span>
+        </div>
+      </div>
+
+      <div className="h-72 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={chartData} margin={{ top: 10, right: 20, left: -10, bottom: 0 }}>
+            <defs>
+              <linearGradient id="areaGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#0ea5e9" stopOpacity={0.6} />
+                <stop offset="95%" stopColor="#0ea5e9" stopOpacity={0.05} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.35)" vertical={false} />
+            <XAxis dataKey="label" tickLine={false} axisLine={false} tick={{ fill: "#64748b", fontSize: 12 }} interval="preserveStartEnd" />
+            <YAxis domain={[1, 5]} tickLine={false} axisLine={false} tick={{ fill: "#64748b", fontSize: 12 }} allowDecimals />
+            <Tooltip
+              cursor={{ stroke: "rgba(14,165,233,0.2)", strokeWidth: 2 }}
+              contentStyle={tooltipStyles}
+              labelStyle={{
+                color: "rgba(226, 232, 240, 0.8)",
+                fontSize: 12,
+                letterSpacing: "0.08em",
+                textTransform: "uppercase",
+              }}
+              formatter={(value: number) => [`${value.toFixed(2)} ★`, "Rating"]}
+            />
+            <Area
+              type="monotone"
+              dataKey="rating"
+              stroke="#0ea5e9"
+              strokeWidth={3}
+              fill="url(#areaGradient)"
+              dot={{ r: 4, fill: "#0ea5e9", strokeWidth: 0 }}
+              activeDot={{ r: 6, strokeWidth: 0 }}
+              animationDuration={800}
+              animationEasing="ease-in-out"
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/syncback/components/ui/label.tsx
+++ b/syncback/components/ui/label.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>;
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn(
+        "text-sm font-medium leading-none text-slate-600 peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+
+Label.displayName = "Label";
+
+export { Label };

--- a/syncback/components/ui/slider.tsx
+++ b/syncback/components/ui/slider.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type SliderBaseProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "value" | "defaultValue" | "onChange" | "min" | "max" | "step"
+> & {
+  min?: number;
+  max?: number;
+  step?: number;
+};
+
+export type SliderProps = SliderBaseProps & {
+  value?: number[];
+  defaultValue?: number[];
+  onValueChange?: (value: number[]) => void;
+};
+
+const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
+  (
+    {
+      className,
+      min = 0,
+      max = 100,
+      step = 1,
+      value,
+      defaultValue,
+      onValueChange,
+      ...props
+    },
+    ref,
+  ) => {
+    const isControlled = value !== undefined;
+    const initial = React.useMemo(() => {
+      if (value && value.length > 0) {
+        return value[0];
+      }
+      if (defaultValue && defaultValue.length > 0) {
+        return defaultValue[0];
+      }
+      return min;
+    }, [defaultValue, min, value]);
+
+    const [internalValue, setInternalValue] = React.useState(initial);
+
+    React.useEffect(() => {
+      if (isControlled && value) {
+        setInternalValue(value[0]);
+      }
+    }, [isControlled, value]);
+
+    React.useEffect(() => {
+      setInternalValue((current) => {
+        if (current < min) return min;
+        if (current > max) return max;
+        return current;
+      });
+    }, [min, max]);
+
+    return (
+      <input
+        ref={ref}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={isControlled ? value?.[0] ?? min : internalValue}
+        onChange={(event) => {
+          const nextValue = Number(event.target.value);
+          if (!isControlled) {
+            setInternalValue(nextValue);
+          }
+          onValueChange?.([nextValue]);
+        }}
+        className={cn(
+          "h-2 w-full appearance-none rounded-full bg-slate-200 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/70 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "[&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-slate-900 [&::-webkit-slider-thumb]:shadow-lg [&::-webkit-slider-thumb]:transition-colors",
+          "[&::-webkit-slider-runnable-track]:h-2 [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-slate-200",
+          "[&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-slate-900",
+          "[&::-moz-range-track]:h-2 [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-slate-200",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+Slider.displayName = "Slider";
+
+export { Slider };


### PR DESCRIPTION
## Summary
- add a recent ratings area chart card that highlights the latest feedback with a configurable window
- build lightweight slider and label primitives to support tick-marked controls in the dashboard
- seed dashboard with sample recent rating data so the chart renders with live values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd178f1ba8832bbc04e9e389054642