### PR TITLE
Enhance feedback table filters and modal

### DIFF
--- a/syncback/components/smoothui/ui/BasicModal.tsx
+++ b/syncback/components/smoothui/ui/BasicModal.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useId, useMemo, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+import { cn } from "@/lib/utils";
+
+type ModalSize = "sm" | "md" | "lg";
+
+type BasicModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  size?: ModalSize;
+  children: ReactNode;
+  className?: string;
+};
+
+const sizeMap: Record<ModalSize, string> = {
+  sm: "max-w-md",
+  md: "max-w-xl",
+  lg: "max-w-3xl",
+};
+
+export default function BasicModal({
+  isOpen,
+  onClose,
+  title,
+  size = "md",
+  children,
+  className,
+}: BasicModalProps) {
+  const [mounted, setMounted] = useState(false);
+  const headingId = useId();
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen, onClose]);
+
+  const content = useMemo(() => {
+    if (!isOpen) {
+      return null;
+    }
+
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-6">
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 cursor-pointer"
+          onClick={onClose}
+        />
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={title ? headingId : undefined}
+          className={cn(
+            "relative z-10 w-full origin-center overflow-hidden rounded-[32px] border border-white/60 bg-white/95 backdrop-blur-xl shadow-[0_40px_80px_-40px_rgba(15,23,42,0.45)] transition duration-200",
+            sizeMap[size],
+            className,
+          )}
+        >
+          <div className="absolute inset-x-0 top-0 h-40 bg-gradient-to-br from-white/40 via-white/60 to-slate-100/80" aria-hidden="true" />
+          <div className="relative flex flex-col gap-6 p-8">
+            {title ? (
+              <div className="flex items-start justify-between gap-6">
+                <div>
+                  <p
+                    id={headingId}
+                    className="text-lg font-semibold tracking-tight text-slate-900"
+                  >
+                    {title}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="inline-flex size-9 items-center justify-center rounded-full border border-slate-200/80 bg-white/80 text-slate-500 shadow-sm transition hover:-translate-y-[1px] hover:border-slate-300 hover:text-slate-900 hover:shadow"
+                  aria-label="Close dialog"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    className="size-4"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M5.22 5.22a.75.75 0 0 1 1.06 0L10 8.94l3.72-3.72a.75.75 0 1 1 1.06 1.06L11.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06L10 11.06l-3.72 3.72a.75.75 0 0 1-1.06-1.06L8.94 10 5.22 6.28a.75.75 0 0 1 0-1.06Z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </button>
+              </div>
+            ) : null}
+            {children}
+          </div>
+        </div>
+      </div>
+    );
+  }, [children, className, headingId, isOpen, onClose, size, title]);
+
+  if (!mounted) {
+    return null;
+  }
+
+  return createPortal(content, document.body);
+}

--- a/syncback/components/ui/calendar-rac.tsx
+++ b/syncback/components/ui/calendar-rac.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  Button,
+  CalendarCell,
+  CalendarGrid,
+  CalendarGridBody,
+  CalendarGridHeader,
+  CalendarHeaderCell,
+  Heading,
+  RangeCalendar as RACRangeCalendar,
+  type RangeCalendarProps,
+} from "react-aria-components";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { DateValue } from "@internationalized/date";
+
+import { cn } from "@/lib/utils";
+
+export function RangeCalendar<T extends DateValue>(
+  props: RangeCalendarProps<T>,
+) {
+  const { className, ...rest } = props;
+
+  return (
+    <RACRangeCalendar
+      {...rest}
+      className={(renderProps) =>
+        cn(
+          "relative flex w-full flex-col gap-3 rounded-3xl border border-slate-200/80 bg-white/95 p-4 text-slate-900 shadow-[0_24px_60px_-32px_rgba(15,23,42,0.4)]",
+          renderProps.isInvalid && "border-rose-200",
+          typeof className === "function" ? className(renderProps) : className,
+        )
+      }
+    >
+      <div className="flex items-center justify-between rounded-2xl bg-slate-50/80 px-3 py-2">
+        <Button
+          slot="previous"
+          className="inline-flex size-9 items-center justify-center rounded-full border border-slate-200/80 bg-white/90 text-slate-500 transition hover:-translate-y-[1px] hover:border-slate-300 hover:text-slate-900 hover:shadow"
+        >
+          <ChevronLeft className="size-4" aria-hidden="true" />
+        </Button>
+        <Heading className="text-sm font-semibold tracking-tight text-slate-900" />
+        <Button
+          slot="next"
+          className="inline-flex size-9 items-center justify-center rounded-full border border-slate-200/80 bg-white/90 text-slate-500 transition hover:-translate-y-[1px] hover:border-slate-300 hover:text-slate-900 hover:shadow"
+        >
+          <ChevronRight className="size-4" aria-hidden="true" />
+        </Button>
+      </div>
+      <CalendarGrid className="w-full border-separate border-spacing-y-2 px-1 text-sm">
+        <CalendarGridHeader className="text-xs font-medium uppercase tracking-[0.3em] text-slate-400">
+          {(day) => <CalendarHeaderCell className="pb-1 text-center">{day}</CalendarHeaderCell>}
+        </CalendarGridHeader>
+        <CalendarGridBody>
+          {(date) => (
+            <CalendarCell
+              date={date}
+              className={({ isSelected, isSelectionStart, isSelectionEnd, isDisabled, isOutsideMonth }) =>
+                cn(
+                  "relative h-10 w-10 select-none rounded-2xl text-center text-sm font-medium leading-10 transition",
+                  isSelected &&
+                    "bg-gradient-to-br from-amber-400 via-amber-500 to-amber-400 text-white shadow-lg",
+                  !isSelected && "text-slate-600",
+                  isSelectionStart && "rounded-s-full",
+                  isSelectionEnd && "rounded-e-full",
+                  isDisabled && "pointer-events-none opacity-40",
+                  isOutsideMonth && "text-slate-300",
+                )
+              }
+            />
+          )}
+        </CalendarGridBody>
+      </CalendarGrid>
+    </RACRangeCalendar>
+  );
+}

--- a/syncback/package-lock.json
+++ b/syncback/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.33.1",
+        "@internationalized/date": "^3.9.0",
         "@mantine/core": "^7.14.2",
         "@mantine/hooks": "^7.14.2",
         "@mantinex/mantine-logo": "^1.0.2",
@@ -23,6 +24,7 @@
         "next": "15.5.4",
         "qrcode-generator": "^1.5.2",
         "react": "19.1.0",
+        "react-aria-components": "^1.12.2",
         "react-dom": "19.1.0",
         "recharts": "^2.12.7",
         "tailwind-merge": "^3.3.1"
@@ -787,6 +789,57 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1265,6 +1318,43 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.9.0.tgz",
+      "integrity": "sha512-yaN3brAnHRD+4KyyOsJyk49XUvj2wtbNACSqg0bz3u8t2VuzhC8Q5dfRnrSxjnnbDb+ienBnkn1TzQfE154vyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/message": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.8.tgz",
+      "integrity": "sha512-Rwk3j/TlYZhn3HQ6PyXUV0XP9Uv42jqZGNegt0BXlxjE6G3+LwHjbQZAGHhCnCPdaA6Tvd3ma/7QzLlLkJxAWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "intl-messageformat": "^10.1.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.5.tgz",
+      "integrity": "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.7.tgz",
+      "integrity": "sha512-D4OHBjrinH+PFZPvfCXvG28n2LSykWcJ7GIioQL+ok0LON15SdfoUssoHzzOUmVZLbRoREsQXVzA6r8JKsbP6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -2070,6 +2160,1801 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
+    },
+    "node_modules/@react-aria/autocomplete": {
+      "version": "3.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/autocomplete/-/autocomplete-3.0.0-rc.2.tgz",
+      "integrity": "sha512-55KVj5FePFTHk8nWfUUNN8m7rBL+aSRE0CxHI2t8JG3uam3nY7jyuAJy34RBuDEdTsVlMO9Fri/1JragePC2dg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/combobox": "^3.13.2",
+        "@react-aria/focus": "^3.21.1",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/listbox": "^3.14.8",
+        "@react-aria/searchfield": "^3.8.8",
+        "@react-aria/textfield": "^3.18.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/autocomplete": "3.0.0-beta.3",
+        "@react-stately/combobox": "^3.11.1",
+        "@react-types/autocomplete": "3.0.0-alpha.34",
+        "@react-types/button": "^3.14.0",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/breadcrumbs": {
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.5.28.tgz",
+      "integrity": "sha512-6S3QelpajodEzN7bm49XXW5gGoZksK++cl191W0sexq/E5hZHAEA9+CFC8pL3px13ji7qHGqKAxOP4IUVBdVpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/link": "^3.8.5",
+        "@react-aria/utils": "^3.30.1",
+        "@react-types/breadcrumbs": "^3.7.16",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/button": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.14.1.tgz",
+      "integrity": "sha512-Ug06unKEYVG3OF6zKmpVR7VfLzpj7eJVuFo3TCUxwFJG7DI28pZi2TaGWnhm7qjkxfl1oz0avQiHVfDC99gSuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/toolbar": "3.0.0-beta.20",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/toggle": "^3.9.1",
+        "@react-types/button": "^3.14.0",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/calendar": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/calendar/-/calendar-3.9.1.tgz",
+      "integrity": "sha512-dCJliRIi3x3VmAZkJDNTZddq0+QoUX9NS7GgdqPPYcJIMbVPbyLWL61//0SrcCr3MuSRCoI1eQZ8PkQe/2PJZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.9.0",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/calendar": "^3.8.4",
+        "@react-types/button": "^3.14.0",
+        "@react-types/calendar": "^3.7.4",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/checkbox": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.16.1.tgz",
+      "integrity": "sha512-YcG3QhuGIwqPHo4GVGVmwxPM5Ayq9CqYfZjla/KTfJILPquAJ12J7LSMpqS/Z5TlMNgIIqZ3ZdrYmjQlUY7eUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.1.1",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/label": "^3.7.21",
+        "@react-aria/toggle": "^3.12.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/checkbox": "^3.7.1",
+        "@react-stately/form": "^3.2.1",
+        "@react-stately/toggle": "^3.9.1",
+        "@react-types/checkbox": "^3.10.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/collections": {
+      "version": "3.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/collections/-/collections-3.0.0-rc.7.tgz",
+      "integrity": "sha512-JMktVhe+OT6rZVcGdmSWgNj3VBq4Owm3L5LD8iMwJrV6SgPGmyzpguX7JTnz1hnSWO/wD2vrwMWEAlcuL7acBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.30.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/color": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/color/-/color-3.1.1.tgz",
+      "integrity": "sha512-4+woybtn4kh5ytggWQ06bqqWsoucOrxwNrwW1XP6EmvcjIcsfVW+VwFwM5ZYa2LGF+fHiW3dM4bjRqVa7i9PVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/numberfield": "^3.12.1",
+        "@react-aria/slider": "^3.8.1",
+        "@react-aria/spinbutton": "^3.6.18",
+        "@react-aria/textfield": "^3.18.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-aria/visually-hidden": "^3.8.27",
+        "@react-stately/color": "^3.9.1",
+        "@react-stately/form": "^3.2.1",
+        "@react-types/color": "^3.1.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/combobox": {
+      "version": "3.13.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.13.2.tgz",
+      "integrity": "sha512-PNyqlaM19A+lKX9hwqkKTXvWDilCKaRH2RdrB/C5AfmGi3bh/IKsu66c8ohgadXB2AIdJB36EOOm3hNh8G9DqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.1",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/listbox": "^3.14.8",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/menu": "^3.19.2",
+        "@react-aria/overlays": "^3.29.1",
+        "@react-aria/selection": "^3.25.1",
+        "@react-aria/textfield": "^3.18.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/combobox": "^3.11.1",
+        "@react-stately/form": "^3.2.1",
+        "@react-types/button": "^3.14.0",
+        "@react-types/combobox": "^3.13.8",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/datepicker": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/datepicker/-/datepicker-3.15.1.tgz",
+      "integrity": "sha512-RfUOvsupON6E5ZELpBgb9qxsilkbqwzsZ78iqCDTVio+5kc5G9jVeHEIQOyHnavi/TmJoAnbmmVpEbE6M9lYJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.9.0",
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/focus": "^3.21.1",
+        "@react-aria/form": "^3.1.1",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/label": "^3.7.21",
+        "@react-aria/spinbutton": "^3.6.18",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/datepicker": "^3.15.1",
+        "@react-stately/form": "^3.2.1",
+        "@react-types/button": "^3.14.0",
+        "@react-types/calendar": "^3.7.4",
+        "@react-types/datepicker": "^3.13.1",
+        "@react-types/dialog": "^3.5.21",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/dialog": {
+      "version": "3.5.30",
+      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.30.tgz",
+      "integrity": "sha512-fiodaeMSTiC4qKNwnCLbNykyvfcxuz/PiU/pBNhWYd4lUrX1TauBQb0++o5/K6OHt8iB+A7/LSHRbPtyOSWE9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/overlays": "^3.29.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-types/dialog": "^3.5.21",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/disclosure": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/disclosure/-/disclosure-3.0.8.tgz",
+      "integrity": "sha512-Q2v6czm3ViMTw7J+GCWdXw3rZ5Fgmy97gpSQjpEoxSyqA1UfpRRvNa+XYoXmbpaY1MGhtUX3m2GgZ4IuhhMHVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/disclosure": "^3.0.7",
+        "@react-types/button": "^3.14.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/dnd": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/dnd/-/dnd-3.11.2.tgz",
+      "integrity": "sha512-xaIUV0zPtUTLIBoE7qlGFPfRTfyDJT78fDzawYq6FwZcjgrl8X408UDCUaKk6xSJRh9UjNn78hil1WDYTLFNWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/overlays": "^3.29.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/dnd": "^3.7.0",
+        "@react-types/button": "^3.14.0",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.1.tgz",
+      "integrity": "sha512-hmH1IhHlcQ2lSIxmki1biWzMbGgnhdxJUM0MFfzc71Rv6YAzhlx4kX3GYn4VNcjCeb6cdPv4RZ5vunV4kgMZYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/utils": "^3.30.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/form": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/form/-/form-3.1.1.tgz",
+      "integrity": "sha512-PjZC25UgH5orit9p56Ymbbo288F3eaDd3JUvD8SG+xgx302HhlFAOYsQLLAb4k4H03bp0gWtlUEkfX6KYcE1Tw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/form": "^3.2.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid": {
+      "version": "3.14.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.14.4.tgz",
+      "integrity": "sha512-l1FLQNKnoHpY4UClUTPUV0AqJ5bfAULEE0ErY86KznWLd+Hqzo7mHLqqDV02CDa/8mIUcdoax/MrYYIbPDlOZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.1",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/selection": "^3.25.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/grid": "^3.11.5",
+        "@react-stately/selection": "^3.20.5",
+        "@react-types/checkbox": "^3.10.1",
+        "@react-types/grid": "^3.3.5",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/gridlist": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/gridlist/-/gridlist-3.14.0.tgz",
+      "integrity": "sha512-8NWDaUbPe6ujI+kSvDqr2onPYWlBXiaLCQ6nfYOo+GFKxeVCsv4a2I5HAAoGf9THNQ5b8b8kJa+M0xyL1Z71XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.1",
+        "@react-aria/grid": "^3.14.4",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/selection": "^3.25.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/list": "^3.13.0",
+        "@react-stately/tree": "^3.9.2",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/i18n": {
+      "version": "3.12.12",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.12.tgz",
+      "integrity": "sha512-JN6p+Xc6Pu/qddGRoeYY6ARsrk2Oz7UiQc9nLEPOt3Ch+blJZKWwDjcpo/p6/wVZdD/2BgXS7El6q6+eMg7ibw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.9.0",
+        "@internationalized/message": "^3.1.8",
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.30.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.25.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.5.tgz",
+      "integrity": "sha512-EweYHOEvMwef/wsiEqV73KurX/OqnmbzKQa2fLxdULbec5+yDj6wVGaRHIzM4NiijIDe+bldEl5DG05CAKOAHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/flags": "^3.1.2",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/label": {
+      "version": "3.7.21",
+      "resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.7.21.tgz",
+      "integrity": "sha512-8G+059/GZahgQbrhMcCcVcrjm7W+pfzrypH/Qkjo7C1yqPGt6geeFwWeOIbiUZoI0HD9t9QvQPryd6m46UC7Tg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.30.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/landmark": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/landmark/-/landmark-3.0.6.tgz",
+      "integrity": "sha512-dMPBqJWTDAr3Lj5hA+XYDH2PWqtFghYy+y7iq7K5sK/96cub8hZEUjhwn+HGgHsLerPp0dWt293nKupAJnf4Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.30.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/link": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.8.5.tgz",
+      "integrity": "sha512-klhV4roPp5MLRXJv1N+7SXOj82vx4gzVpuwQa3vouA+YI1my46oNzwgtkLGSTvE9OvDqYzPDj2YxFYhMywrkuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/utils": "^3.30.1",
+        "@react-types/link": "^3.6.4",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/listbox": {
+      "version": "3.14.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.14.8.tgz",
+      "integrity": "sha512-uRgbuD9afFv0PDhQ/VXCmAwlYctIyKRzxztkqp1p/1yz/tn/hs+bG9kew9AI02PtlRO1mSc+32O+mMDXDer8hA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/label": "^3.7.21",
+        "@react-aria/selection": "^3.25.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/list": "^3.13.0",
+        "@react-types/listbox": "^3.7.3",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/live-announcer": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.4.4.tgz",
+      "integrity": "sha512-PTTBIjNRnrdJOIRTDGNifY2d//kA7GUAwRFJNOEwSNG4FW+Bq9awqLiflw0JkpyB0VNIwou6lqKPHZVLsGWOXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-aria/menu": {
+      "version": "3.19.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.19.2.tgz",
+      "integrity": "sha512-WzDLW2MotL0L5/LEwc5oGgISf2ODuw4FnRpF0Zk+J4tKFfC88odvKz848ubBvThRXuXEvL0BHY+WqtM+j9fn3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.1",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/overlays": "^3.29.1",
+        "@react-aria/selection": "^3.25.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/menu": "^3.9.7",
+        "@react-stately/selection": "^3.20.5",
+        "@react-stately/tree": "^3.9.2",
+        "@react-types/button": "^3.14.0",
+        "@react-types/menu": "^3.10.4",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/meter": {
+      "version": "3.4.26",
+      "resolved": "https://registry.npmjs.org/@react-aria/meter/-/meter-3.4.26.tgz",
+      "integrity": "sha512-BI+Ri0dkhx9jjf6yPbOLl69M6808Fi08KNEmserMEapy++5usB/8krh9ARuR0GZYUPFOcny0Ml0or/HqamyFvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/progress": "^3.4.26",
+        "@react-types/meter": "^3.4.12",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/numberfield": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/numberfield/-/numberfield-3.12.1.tgz",
+      "integrity": "sha512-3KjxGgWiF4GRvIyqrE3nCndkkEJ68v86y0nx89TpAjdzg7gCgdXgU2Lr4BhC/xImrmlqCusw0IBUMhsEq9EQWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/spinbutton": "^3.6.18",
+        "@react-aria/textfield": "^3.18.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/form": "^3.2.1",
+        "@react-stately/numberfield": "^3.10.1",
+        "@react-types/button": "^3.14.0",
+        "@react-types/numberfield": "^3.8.14",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/overlays": {
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.29.1.tgz",
+      "integrity": "sha512-Yz92XNPnbrTnxrvNrY/fXJ3iWaYNrj0q24ddvZNNKDcWak0S1/mQeUwNb+PwS2AryhFU5VQqKz5rNsM96TKmPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.1",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.30.1",
+        "@react-aria/visually-hidden": "^3.8.27",
+        "@react-stately/overlays": "^3.6.19",
+        "@react-types/button": "^3.14.0",
+        "@react-types/overlays": "^3.9.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/progress": {
+      "version": "3.4.26",
+      "resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.4.26.tgz",
+      "integrity": "sha512-EJBzbE0IjXrJ19ofSyNKDnqC70flUM0Z+9heMRPLi6Uz01o6Uuz9tjyzmoPnd9Q1jnTT7dCl7ydhdYTGsWFcUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/label": "^3.7.21",
+        "@react-aria/utils": "^3.30.1",
+        "@react-types/progress": "^3.5.15",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/radio": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.12.1.tgz",
+      "integrity": "sha512-feZdMJyNp+UX03seIX0W6gdUk8xayTY+U0Ct61eci6YXzyyZoL2PVh49ojkbyZ2UZA/eXeygpdF5sgQrKILHCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.1",
+        "@react-aria/form": "^3.1.1",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/label": "^3.7.21",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/radio": "^3.11.1",
+        "@react-types/radio": "^3.9.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/searchfield": {
+      "version": "3.8.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/searchfield/-/searchfield-3.8.8.tgz",
+      "integrity": "sha512-Yn6esCYEym3Cwrh/OZt6o/RFzsG2zyCAEZf7BhWk6NWUvP6aPwHgoSDVSjDN6YnnPn4yMqkqPnZulHV4+MvE/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/textfield": "^3.18.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/searchfield": "^3.5.15",
+        "@react-types/button": "^3.14.0",
+        "@react-types/searchfield": "^3.6.5",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/select": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/select/-/select-3.16.2.tgz",
+      "integrity": "sha512-MwsOJ6FfPxzrLP6spnYg2SUeGKNm4m5vyH6GebecLxTO1ee7/YyTNP1xkrQTqPMP9xx6uqhzFLFuCym2b6ripA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.1.1",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/label": "^3.7.21",
+        "@react-aria/listbox": "^3.14.8",
+        "@react-aria/menu": "^3.19.2",
+        "@react-aria/selection": "^3.25.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-aria/visually-hidden": "^3.8.27",
+        "@react-stately/select": "^3.7.1",
+        "@react-types/button": "^3.14.0",
+        "@react-types/select": "^3.10.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/selection": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.25.1.tgz",
+      "integrity": "sha512-HG+k3rDjuhnXPdVyv9CKiebee2XNkFYeYZBxEGlK3/pFVBzndnc8BXNVrXSgtCHLs2d090JBVKl1k912BPbj0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.1",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/selection": "^3.20.5",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/separator": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/@react-aria/separator/-/separator-3.4.12.tgz",
+      "integrity": "sha512-rvFCPdOPMQKY/Bpv2jNzXtetCuBLYSRCvpzam1LpMaEgwau5yECbId66+M2UX/cscPccKNU537SM6ei2j7RGog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.30.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/slider": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.8.1.tgz",
+      "integrity": "sha512-uPgwZQrcuqHaLU2prJtPEPIyN9ugZ7qGgi0SB2U8tvoODNVwuPvOaSsvR98Mn6jiAzMFNoWMydeIi+J1OjvWsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/label": "^3.7.21",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/slider": "^3.7.1",
+        "@react-types/shared": "^3.32.0",
+        "@react-types/slider": "^3.8.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton": {
+      "version": "3.6.18",
+      "resolved": "https://registry.npmjs.org/@react-aria/spinbutton/-/spinbutton-3.6.18.tgz",
+      "integrity": "sha512-dnmh7sNsprhYTpqCJhcuc9QJ9C/IG/o9TkgW5a9qcd2vS+dzEgqAiJKIMbJFG9kiJymv2NwIPysF12IWix+J3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.30.1",
+        "@react-types/button": "^3.14.0",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/switch": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.7.7.tgz",
+      "integrity": "sha512-auV3g1qh+d/AZk7Idw2BOcYeXfCD9iDaiGmlcLJb9Eaz4nkq8vOkQxIXQFrn9Xhb+PfQzmQYKkt5N6P2ZNsw/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/toggle": "^3.12.1",
+        "@react-stately/toggle": "^3.9.1",
+        "@react-types/shared": "^3.32.0",
+        "@react-types/switch": "^3.5.14",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/table": {
+      "version": "3.17.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.17.7.tgz",
+      "integrity": "sha512-FxXryGTxePgh8plIxlOMwXdleGWjK52vsmbRoqz66lTIHMUMLTmmm+Y0V3lBOIoaW1rxvKcolYgS79ROnbDYBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.1",
+        "@react-aria/grid": "^3.14.4",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.30.1",
+        "@react-aria/visually-hidden": "^3.8.27",
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/table": "^3.15.0",
+        "@react-types/checkbox": "^3.10.1",
+        "@react-types/grid": "^3.3.5",
+        "@react-types/shared": "^3.32.0",
+        "@react-types/table": "^3.13.3",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tabs": {
+      "version": "3.10.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.10.7.tgz",
+      "integrity": "sha512-iA1M6H+N+9GggsEy/6MmxpMpeOocwYgFy2EoEl3it24RVccY6iZT4AweJq96s5IYga5PILpn7VVcpssvhkPgeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.1",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/selection": "^3.25.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/tabs": "^3.8.5",
+        "@react-types/shared": "^3.32.0",
+        "@react-types/tabs": "^3.3.18",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tag": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/tag/-/tag-3.7.1.tgz",
+      "integrity": "sha512-VpF26ez+QmEzTK8E9tXZ4cofa1wocjnIo/Bd1LCXgLCytnHAkYGxeIRm5QbznJ0aF/9UgR1QtMqhyRrCZg9QqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/gridlist": "^3.14.0",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/label": "^3.7.21",
+        "@react-aria/selection": "^3.25.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/list": "^3.13.0",
+        "@react-types/button": "^3.14.0",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/textfield": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.18.1.tgz",
+      "integrity": "sha512-8yCoirnQzbbQgdk5J5bqimEu3GhHZ9FXeMHez1OF+H+lpTwyTYQ9XgioEN3HKnVUBNEufG4lYkQMxTKJdq1v9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.1.1",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/label": "^3.7.21",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/form": "^3.2.1",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.32.0",
+        "@react-types/textfield": "^3.12.5",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toast": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/toast/-/toast-3.0.7.tgz",
+      "integrity": "sha512-nuxPQ7wcSTg9UNMhXl9Uwyc5you/D1RfwymI3VDa5OGTZdJOmV2j94nyjBfMO2168EYMZjw+wEovvOZphs2Pbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/landmark": "^3.0.6",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/toast": "^3.1.2",
+        "@react-types/button": "^3.14.0",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.12.1.tgz",
+      "integrity": "sha512-XaFiRs1KEcIT6bTtVY/KTQxw4kinemj/UwXw2iJTu9XS43hhJ/9cvj8KzNGrKGqaxTpOYj62TnSHZbSiFViHDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/toggle": "^3.9.1",
+        "@react-types/checkbox": "^3.10.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toolbar": {
+      "version": "3.0.0-beta.20",
+      "resolved": "https://registry.npmjs.org/@react-aria/toolbar/-/toolbar-3.0.0-beta.20.tgz",
+      "integrity": "sha512-Kxvqw+TpVOE/eSi8RAQ9xjBQ2uXe8KkRvlRNQWQsrzkZDkXhzqGfQuJnBmozFxqpzSLwaVqQajHFUSvPAScT8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.1",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/utils": "^3.30.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tooltip": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.8.7.tgz",
+      "integrity": "sha512-Aj7DPJYGZ9/+2ZfhkvbN7YMeA5qu4oy4LVQiMCpqNwcFzvhTAVhN7J7cS6KjA64fhd1shKm3BZ693Ez6lSpqwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/tooltip": "^3.5.7",
+        "@react-types/shared": "^3.32.0",
+        "@react-types/tooltip": "^3.4.20",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tree": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/tree/-/tree-3.1.3.tgz",
+      "integrity": "sha512-CWjIvJS540Kzzxs1f4fF0ajPUfYoeptcA6MmXHBlCKE2euRSvKW6F1ZhvLVq81YsYWuAfBKnG2/JsTgBZnGPVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/gridlist": "^3.14.0",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/selection": "^3.25.1",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/tree": "^3.9.2",
+        "@react-types/button": "^3.14.0",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.30.1.tgz",
+      "integrity": "sha512-zETcbDd6Vf9GbLndO6RiWJadIZsBU2MMm23rBACXLmpRztkrIqPEb2RVdlLaq1+GklDx0Ii6PfveVjx+8S5U6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/virtualizer": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@react-aria/virtualizer/-/virtualizer-4.1.9.tgz",
+      "integrity": "sha512-LN5MfnM/fpZegzkqciipyAvPzbi4DNOGGCh98hVlpIT8IdTm0gNW1Ho2vza15EFcYgt9iinCZ9lhLT5HmE2ZtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/virtualizer": "^4.4.3",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/visually-hidden": {
+      "version": "3.8.27",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.27.tgz",
+      "integrity": "sha512-hD1DbL3WnjPnCdlQjwe19bQVRAGJyN0Aaup+s7NNtvZUn7AjoEH78jo8TE+L8yM7z/OZUQF26laCfYqeIwWn4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/utils": "^3.30.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/autocomplete": {
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/autocomplete/-/autocomplete-3.0.0-beta.3.tgz",
+      "integrity": "sha512-YfP/TrvkOCp6j7oqpZxJSvmSeXn+XtbKSOiBOuo+m2zCIhW2ncThmDB9uAUOkpmikDv/LkGKni40RQE8USdGdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.8",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/calendar": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.8.4.tgz",
+      "integrity": "sha512-q9mq0ydOLS5vJoHLnYfSCS/vppfjbg0XHJlAoPR+w+WpYZF4wPP453SrlX9T1DbxCEYFTpcxcMk/O8SDW3miAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.9.0",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/calendar": "^3.7.4",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/checkbox": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.7.1.tgz",
+      "integrity": "sha512-ezfKRJsDuRCLtNoNOi9JXCp6PjffZWLZ/vENW/gbRDL8i46RKC/HpfJrJhvTPmsLYazxPC99Me9iq3v0VoNCsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.2.1",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/checkbox": "^3.10.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/collections": {
+      "version": "3.12.7",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.7.tgz",
+      "integrity": "sha512-0kQc0mI986GOCQHvRy4L0JQiotIK/KmEhR9Mu/6V0GoSdqg5QeUe4kyoNWj3bl03uQXme80v0L2jLHt+fOHHjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/color": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/color/-/color-3.9.1.tgz",
+      "integrity": "sha512-fCj7fFamyuQbL++MOcf4W4d4aFWXYWJ2UI1dKhrXdqVz/ly9CBVjy/MHKQ6xZX2tEiuoPX5NexfxzKKiozE50Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/number": "^3.6.5",
+        "@internationalized/string": "^3.2.7",
+        "@react-stately/form": "^3.2.1",
+        "@react-stately/numberfield": "^3.10.1",
+        "@react-stately/slider": "^3.7.1",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/color": "^3.1.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/combobox": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.11.1.tgz",
+      "integrity": "sha512-ZZh+SaAmddoY+MeJr470oDYA0nGaJm4xoHCBapaBA0JNakGC/wTzF/IRz3tKQT2VYK4rumr1BJLZQydGp7zzeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/form": "^3.2.1",
+        "@react-stately/list": "^3.13.0",
+        "@react-stately/overlays": "^3.6.19",
+        "@react-stately/select": "^3.7.1",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/combobox": "^3.13.8",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/data": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/data/-/data-3.14.0.tgz",
+      "integrity": "sha512-3GUsOXatYohBX2wTQHnJKVQlFfYXnt7IoDDuIaUeM8kXlF+dRSFAOAfPUSGAph6lJz2ht4dq1SEl6ZL/u+dRlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/datepicker": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.15.1.tgz",
+      "integrity": "sha512-t64iYPms9y+MEQgOAu0XUHccbEXWVUWBHJWnYvAmILCHY8ZAOeSPAT1g4v9nzyiApcflSNXgpsvbs9BBEsrWww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.9.0",
+        "@internationalized/string": "^3.2.7",
+        "@react-stately/form": "^3.2.1",
+        "@react-stately/overlays": "^3.6.19",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/datepicker": "^3.13.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/disclosure": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@react-stately/disclosure/-/disclosure-3.0.7.tgz",
+      "integrity": "sha512-ogM2y02uhpGfSOaBKIDz+hEha8qBH6WIRHRkoqdF4sEaR1kfq8LvBWdP1e/OcqHAhuRr28P2Rf0TDicnAnN7uA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/dnd": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/dnd/-/dnd-3.7.0.tgz",
+      "integrity": "sha512-DddpCVkqt6vUPHLqe/2FHxW/gkR4tEt7W0MbFcCeCLbc9lmvzOClPwNpjmU/3UnU+vPQnwGGUeF3HvaxduUq2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/selection": "^3.20.5",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
+      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/form": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/form/-/form-3.2.1.tgz",
+      "integrity": "sha512-btgOPXkwvd6fdWKoepy5Ue43o2932OSkQxozsR7US1ffFLcQc3SNlADHaRChIXSG8ffPo9t0/Sl4eRzaKu3RgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/grid": {
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.11.5.tgz",
+      "integrity": "sha512-4cNjGYaNkcVS2wZoNHUrMRICBpkHStYw57EVemP7MjiWEVu53kzPgR1Iwmti2WFCpi1Lwu0qWNeCfzKpXW4BTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/selection": "^3.20.5",
+        "@react-types/grid": "^3.3.5",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/layout": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/layout/-/layout-4.5.0.tgz",
+      "integrity": "sha512-giN20XXxSjOG/pRSdzKkHhIFochl0Wer2aWCYceXRNSoP0dTPNU7bjn2p3n3atVRdC9iZpmwIiASO5qDf89sLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/table": "^3.15.0",
+        "@react-stately/virtualizer": "^4.4.3",
+        "@react-types/grid": "^3.3.5",
+        "@react-types/shared": "^3.32.0",
+        "@react-types/table": "^3.13.3",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/list": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.13.0.tgz",
+      "integrity": "sha512-Panv8TmaY8lAl3R7CRhyUadhf2yid6VKsRDBCBB1FHQOOeL7lqIraz/oskvpabZincuaIUWqQhqYslC4a6dvuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/selection": "^3.20.5",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/menu": {
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.9.7.tgz",
+      "integrity": "sha512-mfz1YoCgtje61AGxVdQaAFLlOXt9vV5dd1lQljYUPRafA/qu5Ursz4fNVlcavWW9GscebzFQErx+y0oSP7EUtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.19",
+        "@react-types/menu": "^3.10.4",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/numberfield": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/numberfield/-/numberfield-3.10.1.tgz",
+      "integrity": "sha512-lXABmcTneVvXYMGTgZvTCr4E+upOi7VRLL50ZzTMJqHwB/qlEQPAam3dmddQRwIsuCM3MEnL7bSZFFlSYAtkEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/number": "^3.6.5",
+        "@react-stately/form": "^3.2.1",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/numberfield": "^3.8.14",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/overlays": {
+      "version": "3.6.19",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.19.tgz",
+      "integrity": "sha512-swZXfDvxTYd7tKEpijEHBFFaEmbbnCvEhGlmrAz4K72cuRR9O5u+lcla8y1veGBbBSzrIdKNdBoIIJ+qQH+1TQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/overlays": "^3.9.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/radio": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.11.1.tgz",
+      "integrity": "sha512-ld9KWztI64gssg7zSZi9li21sG85Exb+wFPXtCim1TtpnEpmRtB05pXDDS3xkkIU/qOL4eMEnnLO7xlNm0CRIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.2.1",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/radio": "^3.9.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/searchfield": {
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/@react-stately/searchfield/-/searchfield-3.5.15.tgz",
+      "integrity": "sha512-6LVVvm6Z60fetYLLa4B2Q/BIY+fSSknLTw8sjlV+iDEPAknj7MqWtoLz2gSQRTFKvyO7ZCjJoar8ZU/JEqcm+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/searchfield": "^3.6.5",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/select": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/select/-/select-3.7.1.tgz",
+      "integrity": "sha512-vZt4j9yVyOTWWJoP9plXmYaPZH2uMxbjcGMDbiShwsFiK8C2m9b3Cvy44TZehfzCWzpMVR/DYxEYuonEIGA82Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.2.1",
+        "@react-stately/list": "^3.13.0",
+        "@react-stately/overlays": "^3.6.19",
+        "@react-types/select": "^3.10.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/selection": {
+      "version": "3.20.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.20.5.tgz",
+      "integrity": "sha512-YezWUNEn2pz5mQlbhmngiX9HqQsruLSXlkrAzB1DD6aliGrUvPKufTTGCixOaB8KVeCamdiFAgx1WomNplzdQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/slider": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.7.1.tgz",
+      "integrity": "sha512-J+G18m1bZBCNQSXhxGd4GNGDUVonv4Sg7fZL+uLhXUy1x71xeJfFdKaviVvZcggtl0/q5InW41PXho7EouMDEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.32.0",
+        "@react-types/slider": "^3.8.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/table": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.15.0.tgz",
+      "integrity": "sha512-KbvkrVF3sb25IPwyte9JcG5/4J7TgjHSsw7D61d/T/oUFMYPYVeolW9/2y+6u48WPkDJE8HJsurme+HbTN0FQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/grid": "^3.11.5",
+        "@react-stately/selection": "^3.20.5",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/grid": "^3.3.5",
+        "@react-types/shared": "^3.32.0",
+        "@react-types/table": "^3.13.3",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tabs": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.8.5.tgz",
+      "integrity": "sha512-gdeI+NUH3hfqrxkJQSZkt+Zw4G2DrYJRloq/SGxu/9Bu5QD/U0psU2uqxQNtavW5qTChFK+D30rCPXpKlslWAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/list": "^3.13.0",
+        "@react-types/shared": "^3.32.0",
+        "@react-types/tabs": "^3.3.18",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toast": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/toast/-/toast-3.1.2.tgz",
+      "integrity": "sha512-HiInm7bck32khFBHZThTQaAF6e6/qm57F4mYRWdTq8IVeGDzpkbUYibnLxRhk0UZ5ybc6me+nqqPkG/lVmM42Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toggle": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.9.1.tgz",
+      "integrity": "sha512-L6yUdE8xZfQhw4aEFZduF8u4v0VrpYrwWEA4Tu/4qwGIPukH0wd2W21Zpw+vAiLOaDKnxel1nXX68MWnm4QXpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/checkbox": "^3.10.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tooltip": {
+      "version": "3.5.7",
+      "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.5.7.tgz",
+      "integrity": "sha512-GYh764BcYZz+Lclyutyir5I3elNo+vVNYzeNOKmPGZCE3p5B+/8lgZAHKxnRc9qmBlxvofnhMcuQxAPlBhoEkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.19",
+        "@react-types/tooltip": "^3.4.20",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tree": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.9.2.tgz",
+      "integrity": "sha512-jsT1WZZhb7GRmg1iqoib9bULsilIK5KhbE8WrcfIml8NYr4usP4DJMcIYfRuiRtPLhKtUvHSoZ5CMbinPp8PUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/selection": "^3.20.5",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.10.8",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.8.tgz",
+      "integrity": "sha512-SN3/h7SzRsusVQjQ4v10LaVsDc81jyyR0DD5HnsQitm/I5WDpaSr2nRHtyloPFU48jlql1XX/S04T2DLQM7Y3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/virtualizer": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/virtualizer/-/virtualizer-4.4.3.tgz",
+      "integrity": "sha512-kk6ZyMtOT51kZYGUjUhbgEdRBp/OR3WD+Vj9kFoCa1vbY+fGzbpcnjsvR2LDZuEq8W45ruOvdr1c7HRJG4gWxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.30.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/autocomplete": {
+      "version": "3.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/@react-types/autocomplete/-/autocomplete-3.0.0-alpha.34.tgz",
+      "integrity": "sha512-wswz7r0823EWfBZVMVicoDmFw0T6k7LqGlsLivq/2mq1dL62ywPFPtRUNU5nYqgslZYPUZMPyZgKdehKyuwE7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/combobox": "^3.13.8",
+        "@react-types/searchfield": "^3.6.5",
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/breadcrumbs": {
+      "version": "3.7.16",
+      "resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.7.16.tgz",
+      "integrity": "sha512-4J+7b9y6z8QGZqvsBSWQfebx6aIbc+1unQqnZCAlJl9EGzlI6SGdXRsURGkOUGJCV2GqY8bSocc8AZbRXpQ0XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/link": "^3.6.4",
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/button": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.14.0.tgz",
+      "integrity": "sha512-pXt1a+ElxiZyWpX0uznyjy5Z6EHhYxPcaXpccZXyn6coUo9jmCbgg14xR7Odo+JcbfaaISzZTDO7oGLVTcHnpA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/calendar": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.7.4.tgz",
+      "integrity": "sha512-MZDyXtvdHl8CKQGYBkjYwc4ABBq6Mb4Fu7k/4boQAmMQ5Rtz29ouBCJrAs0BpR14B8ZMGzoNIolxS5RLKBmFSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.9.0",
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/checkbox": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.10.1.tgz",
+      "integrity": "sha512-8ZqBoGBxtn6U/znpmyutGtBBaafUzcZnbuvYjwyRSONTrqQ0IhUq6jI/jbnE9r9SslIkbMB8IS1xRh2e63qmEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/color": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-types/color/-/color-3.1.1.tgz",
+      "integrity": "sha512-zBF1Op4AO3mlygUq2gFhEoK3gZp2HgwCMUKkCzoDbrvcaahhVbDbfhRxgXKM/2dg7WkgsqhokdkjYV2mGQadRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0",
+        "@react-types/slider": "^3.8.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/combobox": {
+      "version": "3.13.8",
+      "resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.13.8.tgz",
+      "integrity": "sha512-HGC3X9hmDRsjSZcFiflvJ7vbIgQ2gX/ZDxo1HVtvQqUDbgQCVakCcCdrB44aYgHFnyDiO6hyp7Y7jXtDBaEIIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/datepicker": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.13.1.tgz",
+      "integrity": "sha512-ub+g5pS3WOo5P/3FRNsQSwvlb9CuLl2m6v6KBkRXc5xqKhFd7UjvVpL6Oi/1zwwfow4itvD1t7l1XxgCo7wZ6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.9.0",
+        "@react-types/calendar": "^3.7.4",
+        "@react-types/overlays": "^3.9.1",
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/dialog": {
+      "version": "3.5.21",
+      "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.21.tgz",
+      "integrity": "sha512-jF1gN4bvwYamsLjefaFDnaSKxTa3Wtvn5f7WLjNVZ8ICVoiMBMdUJXTlPQHAL4YWqtCj4hK/3uimR1E+Pwd7Xw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.9.1",
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/form": {
+      "version": "3.7.15",
+      "resolved": "https://registry.npmjs.org/@react-types/form/-/form-3.7.15.tgz",
+      "integrity": "sha512-a7C1RXgMpHX9b1x/+h5YCOJL/2/Ojw9ErOJhLwUWzKUu5JWpQYf8JsXNsuMSndo4YBaiH/7bXFmg09cllHUmow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/grid": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.3.5.tgz",
+      "integrity": "sha512-hG6J2KDfmOHitkWoCa/9DvY1nTO2wgMIApcFoqLv7AWJr9CzvVqo5tIhZZCXiT1AvU2kafJxu9e7sr5GxAT2YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/link": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.6.4.tgz",
+      "integrity": "sha512-eLpIgOPf7GW4DpdMq8UqiRJkriend1kWglz5O9qU+/FM6COtvRnQkEeRhHICUaU2NZUvMRQ30KaGUo3eeZ6b+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/listbox": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.7.3.tgz",
+      "integrity": "sha512-ONgror9uyGmIer5XxpRRNcc8QFVWiOzINrMKyaS8G4l3aP52ZwYpRfwMAVtra8lkVNvXDmO7hthPZkB6RYdNOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/menu": {
+      "version": "3.10.4",
+      "resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.10.4.tgz",
+      "integrity": "sha512-jCFVShLq3eASiuznenjoKBv3j0Jy2KQilAjBxdEp56WkZ5D338y/oY5zR6d25u9M0QslpI0DgwC8BwU7MCsPnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.9.1",
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/meter": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/@react-types/meter/-/meter-3.4.12.tgz",
+      "integrity": "sha512-rx+yrwdesSabPworWRMpQnuT69gm8xt58cAfTDV9eSY1Jo+lO5OPp0OIyKb+U0q/whf60wnn2hsVnXm2fBXKhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/progress": "^3.5.15"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/numberfield": {
+      "version": "3.8.14",
+      "resolved": "https://registry.npmjs.org/@react-types/numberfield/-/numberfield-3.8.14.tgz",
+      "integrity": "sha512-tlGEHJyeQSMlUoO4g9ekoELGJcqsjc/+/FAxo6YQMhQSkuIdkUKZg3UEBKzif4hLw787u80e1D0SxPUi3KO2oA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/overlays": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.9.1.tgz",
+      "integrity": "sha512-UCG3TOu8FLk4j0Pr1nlhv0opcwMoqbGEOUvsSr6ITN6Qs2y0j+KYSYQ7a4+04m3dN//8+9Wjkkid8k+V1dV2CA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/progress": {
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.5.15.tgz",
+      "integrity": "sha512-3SYvEyRt7vq7w0sc6wBYmkPqLMZbhH8FI3Lrnn9r3y8+69/efRjVmmJvwjm1z+c6rukszc2gCjUGTsMPQxVk2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/radio": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.9.1.tgz",
+      "integrity": "sha512-DUCN3msm8QZ0MJrP55FmqMONaadYq6JTxihYFGMLP+NoKRnkxvXqNZ2PlkAOLGy3y4RHOnOF8O1LuJqFCCuxDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/searchfield": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@react-types/searchfield/-/searchfield-3.6.5.tgz",
+      "integrity": "sha512-5hI+Hb1U0bSxrJLvEwFEQfk7n3S+GO4c5W/0WZBG00YlYDY9asr1V0oU1WRmKPJJlRpyfG6PkMHDC3jhdj89ew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0",
+        "@react-types/textfield": "^3.12.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/select": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.10.1.tgz",
+      "integrity": "sha512-teANUr1byOzGsS/r2j7PatV470JrOhKP8En9lscfnqW5CeUghr+0NxkALnPkiEhCObi/Vu8GIcPareD0HNhtFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.32.0.tgz",
+      "integrity": "sha512-t+cligIJsZYFMSPFMvsJMjzlzde06tZMOIOFa1OV5Z0BcMowrb2g4mB57j/9nP28iJIRYn10xCniQts+qadrqQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/slider": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.8.1.tgz",
+      "integrity": "sha512-WxiQWj6iQr5Uft0/KcB9XSr361XnyTmL6eREZZacngA9CjPhRWYP3BRDPcCTuP7fj9Yi4QKMrryyjHqMHP8OKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/switch": {
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.5.14.tgz",
+      "integrity": "sha512-M8kIv97i+ejCel4Ho+Y7tDbpOehymGwPA4ChxibeyD32+deyxu5B6BXxgKiL3l+oTLQ8ihLo3sRESdPFw8vpQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/table": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.13.3.tgz",
+      "integrity": "sha512-/kY/VlXN+8l9saySd6igcsDQ3x8pOVFJAWyMh6gOaOVN7HOJkTMIchmqS+ATa4nege8jZqcdzyGeAmv7mN655A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/grid": "^3.3.5",
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tabs": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.3.18.tgz",
+      "integrity": "sha512-yX/AVlGS7VXCuy2LSm8y8nxUrKVBgnLv+FrtkLqf6jUMtD4KP3k1c4+GPHeScR0HcYzCQF7gCF3Skba1RdYoug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/textfield": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.12.5.tgz",
+      "integrity": "sha512-VXez8KIcop87EgIy00r+tb30xokA309TfJ32Qv5qOYB5SMqoHnb6SYvWL8Ih2PDqCo5eBiiGesSaWYrHnRIL8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tooltip": {
+      "version": "3.4.20",
+      "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.4.20.tgz",
+      "integrity": "sha512-tF1yThwvgSgW8Gu/CLL0p92AUldHR6szlwhwW+ewT318sQlfabMGO4xlCNFdxJYtqTpEXk2rlaVrBuaC//du0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.9.1",
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -3871,6 +5756,12 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -5205,6 +7096,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6672,6 +8575,101 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-aria": {
+      "version": "3.43.2",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.43.2.tgz",
+      "integrity": "sha512-CfaXi3S69SeOkpp6pGc1w5FH8OvGPFphiMrO2tNSlqpYIecgk3gKoXjkqaAr6N+O1gasLMfAAF9sxtvS141qWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/breadcrumbs": "^3.5.28",
+        "@react-aria/button": "^3.14.1",
+        "@react-aria/calendar": "^3.9.1",
+        "@react-aria/checkbox": "^3.16.1",
+        "@react-aria/color": "^3.1.1",
+        "@react-aria/combobox": "^3.13.2",
+        "@react-aria/datepicker": "^3.15.1",
+        "@react-aria/dialog": "^3.5.30",
+        "@react-aria/disclosure": "^3.0.8",
+        "@react-aria/dnd": "^3.11.2",
+        "@react-aria/focus": "^3.21.1",
+        "@react-aria/gridlist": "^3.14.0",
+        "@react-aria/i18n": "^3.12.12",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/label": "^3.7.21",
+        "@react-aria/landmark": "^3.0.6",
+        "@react-aria/link": "^3.8.5",
+        "@react-aria/listbox": "^3.14.8",
+        "@react-aria/menu": "^3.19.2",
+        "@react-aria/meter": "^3.4.26",
+        "@react-aria/numberfield": "^3.12.1",
+        "@react-aria/overlays": "^3.29.1",
+        "@react-aria/progress": "^3.4.26",
+        "@react-aria/radio": "^3.12.1",
+        "@react-aria/searchfield": "^3.8.8",
+        "@react-aria/select": "^3.16.2",
+        "@react-aria/selection": "^3.25.1",
+        "@react-aria/separator": "^3.4.12",
+        "@react-aria/slider": "^3.8.1",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/switch": "^3.7.7",
+        "@react-aria/table": "^3.17.7",
+        "@react-aria/tabs": "^3.10.7",
+        "@react-aria/tag": "^3.7.1",
+        "@react-aria/textfield": "^3.18.1",
+        "@react-aria/toast": "^3.0.7",
+        "@react-aria/tooltip": "^3.8.7",
+        "@react-aria/tree": "^3.1.3",
+        "@react-aria/utils": "^3.30.1",
+        "@react-aria/visually-hidden": "^3.8.27",
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-aria-components": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.12.2.tgz",
+      "integrity": "sha512-BTA697VWy6Who9cpSbll447kqqpwxYvN6QF3/+AmXO+M+KgUXtPZAaNXu/9Sv2LdshU0zhIea4w27ZOt57UzPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.9.0",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/autocomplete": "3.0.0-rc.2",
+        "@react-aria/collections": "3.0.0-rc.7",
+        "@react-aria/dnd": "^3.11.2",
+        "@react-aria/focus": "^3.21.1",
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/overlays": "^3.29.1",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/textfield": "^3.18.1",
+        "@react-aria/toolbar": "3.0.0-beta.20",
+        "@react-aria/utils": "^3.30.1",
+        "@react-aria/virtualizer": "^4.1.9",
+        "@react-stately/autocomplete": "3.0.0-beta.3",
+        "@react-stately/layout": "^4.5.0",
+        "@react-stately/selection": "^3.20.5",
+        "@react-stately/table": "^3.15.0",
+        "@react-stately/utils": "^3.10.8",
+        "@react-stately/virtualizer": "^4.4.3",
+        "@react-types/form": "^3.7.15",
+        "@react-types/grid": "^3.3.5",
+        "@react-types/shared": "^3.32.0",
+        "@react-types/table": "^3.13.3",
+        "@swc/helpers": "^0.5.0",
+        "client-only": "^0.0.1",
+        "react-aria": "^3.43.2",
+        "react-stately": "^3.41.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -6760,6 +8758,43 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-stately": {
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.41.0.tgz",
+      "integrity": "sha512-Fe8PaZPm9Ue9kDXVa8KaOz6gzbmZPuzftxeVQwKVX3u/kyFhbRkr/LeAFvgP7a+EeX+Bjmdht/9ixDsBXj4qbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/calendar": "^3.8.4",
+        "@react-stately/checkbox": "^3.7.1",
+        "@react-stately/collections": "^3.12.7",
+        "@react-stately/color": "^3.9.1",
+        "@react-stately/combobox": "^3.11.1",
+        "@react-stately/data": "^3.14.0",
+        "@react-stately/datepicker": "^3.15.1",
+        "@react-stately/disclosure": "^3.0.7",
+        "@react-stately/dnd": "^3.7.0",
+        "@react-stately/form": "^3.2.1",
+        "@react-stately/list": "^3.13.0",
+        "@react-stately/menu": "^3.9.7",
+        "@react-stately/numberfield": "^3.10.1",
+        "@react-stately/overlays": "^3.6.19",
+        "@react-stately/radio": "^3.11.1",
+        "@react-stately/searchfield": "^3.5.15",
+        "@react-stately/select": "^3.7.1",
+        "@react-stately/selection": "^3.20.5",
+        "@react-stately/slider": "^3.7.1",
+        "@react-stately/table": "^3.15.0",
+        "@react-stately/tabs": "^3.8.5",
+        "@react-stately/toast": "^3.1.2",
+        "@react-stately/toggle": "^3.9.1",
+        "@react-stately/tooltip": "^3.5.7",
+        "@react-stately/tree": "^3.9.2",
+        "@react-types/shared": "^3.32.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/react-style-singleton": {

--- a/syncback/package.json
+++ b/syncback/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.33.1",
+    "@internationalized/date": "^3.9.0",
     "@mantine/core": "^7.14.2",
     "@mantine/hooks": "^7.14.2",
     "@mantinex/mantine-logo": "^1.0.2",
@@ -24,6 +25,7 @@
     "next": "15.5.4",
     "qrcode-generator": "^1.5.2",
     "react": "19.1.0",
+    "react-aria-components": "^1.12.2",
     "react-dom": "19.1.0",
     "recharts": "^2.12.7",
     "tailwind-merge": "^3.3.1"


### PR DESCRIPTION
## Summary
- replace the feedback detail overlay with a reusable Smooth UI BasicModal and refreshed star styling
- add an Origin UI-inspired range calendar for the date filter and fix the rating dropdown so selections apply
- introduce supporting Smooth UI and calendar components plus dependencies for the new picker

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd7bfc18fc832bb5e17f0dc0b0413f