### PR TITLE
Refresh public feedback styling

### DIFF
--- a/syncback/app/(public)/[businessId]/feedback/page.tsx
+++ b/syncback/app/(public)/[businessId]/feedback/page.tsx
@@ -51,24 +51,24 @@ export default async function FeedbackPage({
   }
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900 text-white">
+    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950">
       <div className="pointer-events-none absolute inset-0">
-        <div className="absolute left-1/2 top-[-15%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(59,130,246,0.35),_rgba(15,23,42,0))] blur-3xl" />
-        <div className="absolute left-[12%] top-[28%] h-72 w-72 rounded-full bg-[radial-gradient(circle_at_center,_rgba(236,72,153,0.25),_rgba(15,23,42,0))] blur-3xl" />
-        <div className="absolute right-[10%] bottom-[18%] h-80 w-80 rounded-full bg-[radial-gradient(circle_at_center,_rgba(45,212,191,0.25),_rgba(15,23,42,0))] blur-3xl" />
-        <div className="absolute inset-0 bg-grid-soft opacity-30" />
+        <div className="absolute left-1/2 top-[-18%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(59,130,246,0.28),_rgba(245,247,255,0))] blur-3xl" />
+        <div className="absolute left-[10%] top-[32%] h-72 w-72 rounded-full bg-[radial-gradient(circle_at_center,_rgba(236,72,153,0.24),_rgba(245,247,255,0))] blur-3xl" />
+        <div className="absolute right-[12%] bottom-[20%] h-80 w-80 rounded-full bg-[radial-gradient(circle_at_center,_rgba(45,212,191,0.22),_rgba(245,247,255,0))] blur-3xl" />
+        <div className="absolute inset-0 bg-grid-soft opacity-40" />
         <div className="absolute inset-0 bg-noise opacity-30 mix-blend-soft-light" />
       </div>
 
       <div className="relative mx-auto flex w-full max-w-5xl flex-col gap-10 px-6 pb-16 pt-20 sm:px-8">
         <div className="space-y-4 text-center">
-          <p className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-sky-100 backdrop-blur">
+          <p className="inline-flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm font-medium text-sky-600 shadow-sm backdrop-blur">
             We love hearing from you
           </p>
-          <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+          <h1 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
             Share your experience with {business.name}
           </h1>
-          <p className="mx-auto max-w-2xl text-base text-slate-200 sm:text-lg">
+          <p className="mx-auto max-w-2xl text-base text-slate-600 sm:text-lg">
             Your voice helps {business.name} celebrate the wins and spot the moments to improve. Rate your visit and leave a few words below.
           </p>
         </div>

--- a/syncback/app/(public)/[businessId]/feedback/ui/feedback-form.tsx
+++ b/syncback/app/(public)/[businessId]/feedback/ui/feedback-form.tsx
@@ -42,7 +42,7 @@ function StarVisual({ variant }: { variant: "empty" | "half" | "full" }) {
     );
   }
 
-  return <Star className="pointer-events-none h-9 w-9 text-slate-500" strokeWidth={1.3} />;
+  return <Star className="pointer-events-none h-9 w-9 text-slate-300" strokeWidth={1.3} />;
 }
 
 function clampRating(value: number) {
@@ -91,7 +91,7 @@ function RatingSelector({ value, onChange }: RatingSelectorProps) {
 
   return (
     <div
-      className="group rounded-2xl border border-white/10 bg-white/5 px-5 py-4 backdrop-blur"
+      className="group rounded-3xl border border-slate-200/80 bg-white/90 px-5 py-4 shadow-sm shadow-slate-900/5 backdrop-blur"
       role="slider"
       aria-label="Rate your visit"
       aria-valuenow={value}
@@ -104,10 +104,10 @@ function RatingSelector({ value, onChange }: RatingSelectorProps) {
     >
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-medium uppercase tracking-[0.2em] text-slate-200">
+          <span className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500">
             Your rating
           </span>
-          <span className="rounded-full bg-white/10 px-3 py-1 text-sm font-semibold text-sky-100">
+          <span className="rounded-full bg-sky-100 px-3 py-1 text-sm font-semibold text-sky-700">
             {displayValue.toFixed(1)} / 5.0
           </span>
         </div>
@@ -167,7 +167,7 @@ export default function FeedbackForm({ business }: FeedbackFormProps) {
   return (
     <form
       action={formAction}
-      className="relative rounded-[32px] border border-white/15 bg-white/10 p-6 text-left shadow-[0_20px_60px_rgba(15,23,42,0.45)] backdrop-blur-xl sm:p-10"
+      className="relative rounded-[32px] border border-white/80 bg-white/90 p-6 text-left shadow-[0_30px_60px_rgba(15,23,42,0.12)] backdrop-blur sm:p-10"
     >
       <input type="hidden" name="slug" value={business.slug} />
       <input type="hidden" name="rating" value={rating.toString()} />
@@ -185,13 +185,13 @@ export default function FeedbackForm({ business }: FeedbackFormProps) {
           required
         />
         {state.status === "error" ? (
-          <div className="rounded-2xl border border-red-400/50 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+          <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-600">
             {state.message ?? "We couldn’t save your feedback. Please try again."}
           </div>
         ) : null}
       </div>
       <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <p className="text-sm text-slate-200/80">
+        <p className="text-sm text-slate-500">
           We’ll share your note directly with the {business.name} team.
         </p>
         <button
@@ -200,8 +200,8 @@ export default function FeedbackForm({ business }: FeedbackFormProps) {
           className={clsx(
             "inline-flex items-center justify-center rounded-full px-6 py-3 text-sm font-semibold tracking-wide transition-all duration-200",
             disableSubmit
-              ? "cursor-not-allowed bg-slate-500/40 text-slate-200/60"
-              : "bg-sky-400 text-slate-950 shadow-lg shadow-sky-500/30 hover:bg-sky-300",
+              ? "cursor-not-allowed bg-slate-200 text-slate-400"
+              : "bg-slate-900 text-white shadow-lg shadow-slate-900/20 hover:bg-slate-800",
           )}
         >
           {isPending ? "Sending feedback…" : "Send feedback"}


### PR DESCRIPTION
## Summary
- restyle the standalone feedback page with the same airy gradient treatment as the marketing site
- refresh the rating selector and submission form so the components feel lighter and more premium
- update supporting states like error messaging and disabled buttons to match the refined palette

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd8c924570832b905e83bc481445b2