### PR TITLE
Enhance public feedback UX with new success and 404 pages

### DIFF
--- a/syncback/app/(public)/[businessId]/feedback/success/page.tsx
+++ b/syncback/app/(public)/[businessId]/feedback/success/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { CheckCircle2, Sparkles } from "lucide-react";
+import { ArrowRight, CheckCircle2, Sparkles } from "lucide-react";
 
 import { api } from "@/convex/_generated/api";
 import { getConvexClient } from "@/lib/convexClient";
@@ -51,40 +51,71 @@ export default async function FeedbackSuccessPage({
   }
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900 text-white">
+    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950">
       <div className="pointer-events-none absolute inset-0">
-        <div className="absolute left-1/2 top-[-20%] h-[380px] w-[380px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.35),_rgba(15,23,42,0))] blur-3xl" />
-        <div className="absolute left-[16%] top-[30%] h-60 w-60 rounded-full bg-[radial-gradient(circle_at_center,_rgba(244,114,182,0.25),_rgba(15,23,42,0))] blur-3xl" />
-        <div className="absolute right-[18%] bottom-[20%] h-72 w-72 rounded-full bg-[radial-gradient(circle_at_center,_rgba(96,165,250,0.25),_rgba(15,23,42,0))] blur-3xl" />
-        <div className="absolute inset-0 bg-grid-soft opacity-30" />
+        <div className="absolute left-1/2 top-[-18%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.32),_rgba(245,247,255,0))] blur-3xl" />
+        <div className="absolute left-[12%] top-[32%] h-72 w-72 rounded-full bg-[radial-gradient(circle_at_center,_rgba(244,114,182,0.22),_rgba(245,247,255,0))] blur-3xl" />
+        <div className="absolute right-[16%] bottom-[22%] h-80 w-80 rounded-full bg-[radial-gradient(circle_at_center,_rgba(14,165,233,0.24),_rgba(245,247,255,0))] blur-3xl" />
+        <div className="absolute inset-0 bg-grid-soft opacity-40" />
         <div className="absolute inset-0 bg-noise opacity-30 mix-blend-soft-light" />
       </div>
 
-      <div className="relative mx-auto flex min-h-screen w-full max-w-4xl flex-col items-center justify-center px-6 py-20 text-center sm:px-8">
-        <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-sky-100 backdrop-blur">
-          <Sparkles className="h-4 w-4 text-sky-200" aria-hidden />
-          Feedback delivered
-        </div>
-        <CheckCircle2 className="mt-10 h-16 w-16 text-emerald-300" strokeWidth={1.6} aria-hidden />
-        <h1 className="mt-6 text-3xl font-semibold tracking-tight sm:text-4xl">
-          Thanks for sharing with {business.name}
-        </h1>
-        <p className="mt-4 max-w-2xl text-base text-slate-200 sm:text-lg">
-          Your feedback is now in the hands of the {business.name} team. Every response helps them celebrate what’s working and refine what comes next.
-        </p>
-        <div className="mt-10 flex flex-col gap-3 sm:flex-row">
-          <Link
-            href={`/${business.slug}/feedback`}
-            className="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-950 transition hover:bg-slate-100"
-          >
-            Share another response
-          </Link>
-          <Link
-            href="https://syncback.app"
-            className="inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-semibold text-white transition hover:border-white/40"
-          >
-            Learn more about SyncBack
-          </Link>
+      <div className="relative mx-auto flex min-h-screen w-full max-w-5xl flex-col items-center justify-center px-6 py-20 sm:px-8">
+        <div className="w-full max-w-3xl rounded-[32px] border border-white/80 bg-white/95 p-8 text-center shadow-[0_30px_60px_rgba(15,23,42,0.12)] backdrop-blur-sm sm:p-12">
+          <div className="mx-auto inline-flex items-center gap-2 rounded-full border border-sky-200/60 bg-sky-50/80 px-4 py-2 text-sm font-medium text-sky-700 shadow-sm">
+            <Sparkles className="h-4 w-4" aria-hidden />
+            Feedback delivered
+          </div>
+          <CheckCircle2 className="mx-auto mt-10 h-16 w-16 text-emerald-500" strokeWidth={1.6} aria-hidden />
+          <h1 className="mt-6 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+            Thanks for sharing with {business.name}
+          </h1>
+          <p className="mt-4 text-base text-slate-600 sm:text-lg">
+            We’ve passed your note directly to the {business.name} crew. Their team reviews every response to celebrate what guests love and smooth out the rough edges.
+          </p>
+          <div className="mt-8 grid gap-6 rounded-3xl border border-slate-200/70 bg-slate-50/70 p-6 text-left text-sm text-slate-600 sm:grid-cols-2">
+            <div className="space-y-2">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">What happens next</h2>
+              <ul className="space-y-2 text-sm leading-6">
+                <li className="flex items-start gap-2">
+                  <span className="mt-1 h-2 w-2 rounded-full bg-emerald-500" aria-hidden />
+                  Your rating is instantly logged in SyncBack for the {business.name} leadership team.
+                </li>
+                <li className="flex items-start gap-2">
+                  <span className="mt-1 h-2 w-2 rounded-full bg-sky-500" aria-hidden />
+                  They’ll review trends and follow up with their team to keep improving the experience.
+                </li>
+              </ul>
+            </div>
+            <div className="space-y-2">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">Want to do more?</h2>
+              <ul className="space-y-2 text-sm leading-6">
+                <li className="flex items-start gap-2">
+                  <span className="mt-1 h-2 w-2 rounded-full bg-amber-500" aria-hidden />
+                  Share another visit or update your thoughts any time you stop by.
+                </li>
+                <li className="flex items-start gap-2">
+                  <span className="mt-1 h-2 w-2 rounded-full bg-violet-500" aria-hidden />
+                  Explore how SyncBack helps businesses craft unforgettable guest journeys.
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <Link
+              href={`/${business.slug}/feedback`}
+              className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-900/10 transition hover:bg-slate-800"
+            >
+              Share another response
+            </Link>
+            <Link
+              href="https://syncback.app"
+              className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300/70 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-400"
+            >
+              Learn more about SyncBack
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/syncback/app/(public)/[businessId]/feedback/ui/feedback-form.tsx
+++ b/syncback/app/(public)/[businessId]/feedback/ui/feedback-form.tsx
@@ -5,8 +5,6 @@ import { useRouter } from "next/navigation";
 import clsx from "clsx";
 import { Star } from "lucide-react";
 
-import AnimatedInput from "@/components/smoothui/ui/AnimatedInput";
-
 import { submitFeedback, type SubmitFeedbackState } from "../actions";
 
 type PublicBusiness = {
@@ -173,17 +171,30 @@ export default function FeedbackForm({ business }: FeedbackFormProps) {
       <input type="hidden" name="rating" value={rating.toString()} />
       <div className="space-y-6">
         <RatingSelector value={rating} onChange={setRating} />
-        <AnimatedInput
-          textarea
-          label="Tell us about your visit"
-          name="message"
-          value={message}
-          onValueChange={setMessage}
-          placeholder="What stood out? What could be even better?"
-          minLength={8}
-          rows={5}
-          required
-        />
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <label
+              htmlFor="message"
+              className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500"
+            >
+              Tell us about your visit
+            </label>
+            <p className="text-sm text-slate-500">
+              Share a few highlights, surprises, or opportunities you spotted during your time with {business.name}.
+            </p>
+          </div>
+          <textarea
+            id="message"
+            name="message"
+            value={message}
+            onChange={(event) => setMessage(event.target.value)}
+            placeholder="What stood out? What could be even better?"
+            minLength={8}
+            rows={5}
+            required
+            className="w-full resize-none rounded-3xl border border-slate-200/80 bg-white/95 px-5 py-4 text-base text-slate-700 shadow-sm shadow-slate-900/5 transition focus:border-sky-400 focus:outline-none focus:ring-4 focus:ring-sky-100"
+          />
+        </div>
         {state.status === "error" ? (
           <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-600">
             {state.message ?? "We couldn’t save your feedback. Please try again."}

--- a/syncback/app/not-found.tsx
+++ b/syncback/app/not-found.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { ArrowLeft, Compass } from "lucide-react";
+
+export default function NotFoundPage() {
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute left-1/2 top-[-18%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.28),_rgba(245,247,255,0))] blur-3xl" />
+        <div className="absolute left-[10%] top-[34%] h-72 w-72 rounded-full bg-[radial-gradient(circle_at_center,_rgba(236,72,153,0.22),_rgba(245,247,255,0))] blur-3xl" />
+        <div className="absolute right-[14%] bottom-[20%] h-80 w-80 rounded-full bg-[radial-gradient(circle_at_center,_rgba(139,92,246,0.24),_rgba(245,247,255,0))] blur-3xl" />
+        <div className="absolute inset-0 bg-grid-soft opacity-40" />
+        <div className="absolute inset-0 bg-noise opacity-30 mix-blend-soft-light" />
+      </div>
+
+      <div className="relative mx-auto flex min-h-screen w-full max-w-5xl items-center justify-center px-6 py-20 sm:px-8">
+        <div className="w-full max-w-3xl rounded-[32px] border border-white/80 bg-white/95 p-8 text-center shadow-[0_30px_60px_rgba(15,23,42,0.12)] backdrop-blur-sm sm:p-12">
+          <div className="mx-auto inline-flex items-center gap-2 rounded-full border border-amber-200/70 bg-amber-50/80 px-4 py-2 text-sm font-medium text-amber-700 shadow-sm">
+            <Compass className="h-4 w-4" aria-hidden />
+            Page not found
+          </div>
+          <h1 className="mt-6 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+            We can’t find the page you’re looking for
+          </h1>
+          <p className="mt-4 text-base text-slate-600 sm:text-lg">
+            The link might be out of date or the page may have moved. Try heading back to the dashboard or explore our latest updates.
+          </p>
+          <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center gap-2 rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-900/10 transition hover:bg-slate-800"
+            >
+              <ArrowLeft className="h-4 w-4" aria-hidden />
+              Back to home
+            </Link>
+            <Link
+              href="/dashboard"
+              className="inline-flex items-center justify-center rounded-full border border-slate-300/70 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-400"
+            >
+              Go to dashboard
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the Smooth UI animated textarea with a styled native field in the public feedback form
- redesign the feedback success screen to match the light glassmorphism aesthetic used throughout the site
- add a custom 404 page that keeps visitors oriented and offers navigation back to core areas

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd8ebe3030832b80449c4541abda40