### PR TITLE
Revamp 404 page with light illustration layout

### DIFF
--- a/syncback/app/not-found.tsx
+++ b/syncback/app/not-found.tsx
@@ -1,43 +1,38 @@
+import Image from "next/image";
 import Link from "next/link";
-import { ArrowLeft, Compass } from "lucide-react";
 
 export default function NotFoundPage() {
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950">
-      <div className="pointer-events-none absolute inset-0">
-        <div className="absolute left-1/2 top-[-18%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.28),_rgba(245,247,255,0))] blur-3xl" />
-        <div className="absolute left-[10%] top-[34%] h-72 w-72 rounded-full bg-[radial-gradient(circle_at_center,_rgba(236,72,153,0.22),_rgba(245,247,255,0))] blur-3xl" />
-        <div className="absolute right-[14%] bottom-[20%] h-80 w-80 rounded-full bg-[radial-gradient(circle_at_center,_rgba(139,92,246,0.24),_rgba(245,247,255,0))] blur-3xl" />
-        <div className="absolute inset-0 bg-grid-soft opacity-40" />
-        <div className="absolute inset-0 bg-noise opacity-30 mix-blend-soft-light" />
-      </div>
-
-      <div className="relative mx-auto flex min-h-screen w-full max-w-5xl items-center justify-center px-6 py-20 sm:px-8">
-        <div className="w-full max-w-3xl rounded-[32px] border border-white/80 bg-white/95 p-8 text-center shadow-[0_30px_60px_rgba(15,23,42,0.12)] backdrop-blur-sm sm:p-12">
-          <div className="mx-auto inline-flex items-center gap-2 rounded-full border border-amber-200/70 bg-amber-50/80 px-4 py-2 text-sm font-medium text-amber-700 shadow-sm">
-            <Compass className="h-4 w-4" aria-hidden />
-            Page not found
+    <div className="flex min-h-screen items-center bg-gradient-to-b from-white via-[#f5f7ff] to-white">
+      <div className="mx-auto w-full max-w-5xl px-6 py-24 lg:px-8">
+        <div className="grid items-center gap-16 lg:grid-cols-[minmax(0,1fr)_minmax(320px,400px)] lg:gap-20">
+          <div className="order-2 text-center lg:order-1 lg:text-left">
+            <p className="text-sm font-semibold uppercase tracking-wide text-sky-500">404 error</p>
+            <h1 className="mt-4 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+              Something is not right...
+            </h1>
+            <p className="mt-4 text-lg leading-relaxed text-slate-600">
+              The page you are trying to open does not exist. You may have mistyped the address, or the page has been moved to
+              another URL. If you think this is an error, contact support.
+            </p>
+            <div className="mt-8 flex flex-col items-center gap-4 sm:flex-row sm:justify-start">
+              <Link
+                href="/"
+                className="inline-flex w-full items-center justify-center rounded-full border border-slate-200 bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-sm transition hover:border-slate-300 hover:shadow-md sm:w-auto"
+              >
+                Get back to home page
+              </Link>
+            </div>
           </div>
-          <h1 className="mt-6 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
-            We can’t find the page you’re looking for
-          </h1>
-          <p className="mt-4 text-base text-slate-600 sm:text-lg">
-            The link might be out of date or the page may have moved. Try heading back to the dashboard or explore our latest updates.
-          </p>
-          <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
-            <Link
-              href="/"
-              className="inline-flex items-center justify-center gap-2 rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-900/10 transition hover:bg-slate-800"
-            >
-              <ArrowLeft className="h-4 w-4" aria-hidden />
-              Back to home
-            </Link>
-            <Link
-              href="/dashboard"
-              className="inline-flex items-center justify-center rounded-full border border-slate-300/70 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-400"
-            >
-              Go to dashboard
-            </Link>
+
+          <div className="order-1 mx-auto h-72 w-full max-w-sm lg:order-2 lg:hidden">
+            <Image src="/not-found-illustration.svg" alt="Person exploring a map on a tablet" width={400} height={400} priority className="h-full w-full object-contain" />
+          </div>
+
+          <div className="relative order-3 hidden justify-center lg:flex">
+            <div className="relative h-[420px] w-full max-w-sm">
+              <Image src="/not-found-illustration.svg" alt="Person exploring a map on a tablet" fill priority className="object-contain" sizes="(min-width: 1024px) 320px, 100vw" />
+            </div>
           </div>
         </div>
       </div>

--- a/syncback/public/not-found-illustration.svg
+++ b/syncback/public/not-found-illustration.svg
@@ -1,0 +1,49 @@
+<svg width="640" height="640" viewBox="0 0 640 640" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="640" rx="56" fill="url(#paint0_linear)"/>
+  <g filter="url(#filter0_dd)">
+    <rect x="118" y="164" width="404" height="312" rx="32" fill="white"/>
+  </g>
+  <rect x="162" y="210" width="145" height="16" rx="8" fill="#D4E4FF"/>
+  <rect x="162" y="244" width="230" height="12" rx="6" fill="#E3EDFF"/>
+  <rect x="162" y="268" width="188" height="12" rx="6" fill="#E3EDFF"/>
+  <rect x="162" y="292" width="214" height="12" rx="6" fill="#E3EDFF"/>
+  <rect x="162" y="316" width="170" height="12" rx="6" fill="#E3EDFF"/>
+  <rect x="162" y="364" width="316" height="40" rx="20" fill="#3069FE" opacity="0.12"/>
+  <g filter="url(#filter1_dd)">
+    <circle cx="408" cy="260" r="60" fill="#EDF3FF"/>
+  </g>
+  <path d="M406.143 303.287C385.455 303.287 368.679 286.51 368.679 265.823C368.679 245.136 385.455 228.359 406.143 228.359C426.83 228.359 443.607 245.136 443.607 265.823" stroke="#3069FE" stroke-width="9.2" stroke-linecap="round"/>
+  <path d="M413.857 302.807C434.545 302.807 451.321 286.03 451.321 265.343" stroke="#3069FE" stroke-width="9.2" stroke-linecap="round"/>
+  <path d="M357.5 372.5C357.5 360.626 367.126 351 379 351H431C442.874 351 452.5 360.626 452.5 372.5V372.5C452.5 384.374 442.874 394 431 394H379C367.126 394 357.5 384.374 357.5 372.5V372.5Z" fill="#3069FE"/>
+  <path d="M218.5 444C218.5 417.61 239.61 396.5 266 396.5H374C400.39 396.5 421.5 417.61 421.5 444C421.5 470.39 400.39 491.5 374 491.5H266C239.61 491.5 218.5 470.39 218.5 444Z" fill="#F1F6FF"/>
+  <path d="M171 444C171 393.011 212.011 352 263 352H377C427.989 352 469 393.011 469 444" stroke="#9CB8FF" stroke-width="13" stroke-linecap="round"/>
+  <path d="M190 444C190 403.131 223.131 370 264 370H376C416.869 370 450 403.131 450 444" stroke="#3069FE" stroke-width="13" stroke-linecap="round"/>
+  <defs>
+    <filter id="filter0_dd" x="98" y="144" width="444" height="352" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="8"/>
+      <feGaussianBlur stdDeviation="10"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.235294 0 0 0 0 0.345098 0 0 0 0 0.968627 0 0 0 0.08 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feOffset dy="16"/>
+      <feGaussianBlur stdDeviation="18"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.101961 0 0 0 0 0.172549 0 0 0 0 0.466667 0 0 0 0.06 0"/>
+      <feBlend mode="normal" in2="effect1_dropShadow" result="effect2_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape"/>
+    </filter>
+    <filter id="filter1_dd" x="332" y="184" width="152" height="152" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="6"/>
+      <feGaussianBlur stdDeviation="18"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.227451 0 0 0 0 0.411765 0 0 0 0 0.960784 0 0 0 0.12 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+    </filter>
+    <linearGradient id="paint0_linear" x1="120" y1="52" x2="520" y2="572" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F7FAFF"/>
+      <stop offset="1" stop-color="#EEF3FF"/>
+    </linearGradient>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary
- rebuild the not found page with a bright, two-column layout inspired by the Mantine example
- add responsive illustration variants to keep the experience polished on mobile and desktop
- introduce a bespoke light SVG illustration that fits the rest of the app styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd902a7698832b9aafbfa42468ac1d