### PR TITLE
Connect dashboard to live feedback data

### DIFF
--- a/syncback/app/(dashboard)/dashboard/page.tsx
+++ b/syncback/app/(dashboard)/dashboard/page.tsx
@@ -11,107 +11,6 @@ import { getConvexClient } from "@/lib/convexClient";
 
 import { resolveAppUrl } from "../settings/actions";
 
-const ratingsTrend = [
-  { month: "May", average: 4.3 },
-  { month: "Jun", average: 4.4 },
-  { month: "Jul", average: 2.5 },
-  { month: "Aug", average: 4.6 },
-  { month: "Sep", average: 4.7 },
-  { month: "Oct", average: 3.8 },
-];
-
-const ratingDistribution = [
-  { segment: "5 Stars", value: 62 },
-  { segment: "4 Stars", value: 24 },
-  { segment: "3 Stars", value: 8 },
-  { segment: "2 Stars", value: 4 },
-  { segment: "1 Star", value: 2 },
-];
-
-const recentRatings = [
-  { rating: 3.9, receivedAt: "2024-09-19T13:32:00Z" },
-  { rating: 4.8, receivedAt: "2024-09-21T09:14:00Z" },
-  { rating: 5, receivedAt: "2024-09-22T16:05:00Z" },
-  { rating: 4.6, receivedAt: "2024-09-23T11:47:00Z" },
-  { rating: 4.7, receivedAt: "2024-09-24T18:22:00Z" },
-  { rating: 4.5, receivedAt: "2024-09-25T20:41:00Z" },
-  { rating: 3.2, receivedAt: "2024-09-26T08:03:00Z" },
-  { rating: 4.9, receivedAt: "2024-09-27T12:18:00Z" },
-  { rating: 4.4, receivedAt: "2024-09-28T15:55:00Z" },
-  { rating: 4.7, receivedAt: "2024-09-29T10:29:00Z" },
-  { rating: 4.9, receivedAt: "2024-09-30T14:36:00Z" },
-  { rating: 5, receivedAt: "2024-10-01T09:22:00Z" },
-  { rating: 4.8, receivedAt: "2024-10-02T17:11:00Z" },
-  { rating: 4.6, receivedAt: "2024-10-03T11:58:00Z" },
-  { rating: 4.7, receivedAt: "2024-10-04T19:37:00Z" },
-  { rating: 4.9, receivedAt: "2024-10-05T13:06:00Z" },
-  { rating: 1.8, receivedAt: "2024-10-06T08:44:00Z" },
-  { rating: 5, receivedAt: "2024-10-07T15:23:00Z" },
-];
-
-const recentFeedback = [
-  {
-    id: "1",
-    receivedAt: "2024-10-07T15:23:00Z",
-    feedback: "Our team appreciated how friendly and attentive your staff were during the dinner rush!",
-    rating: 5,
-  },
-  {
-    id: "2",
-    receivedAt: "2024-10-06T08:44:00Z",
-    feedback: "Loved the seasonal latte, though the wait time for pickup was a little longer than expected.",
-    rating: 4.2,
-  },
-  {
-    id: "3",
-    receivedAt: "2024-10-05T13:06:00Z",
-    feedback: "The lobby music was a bit loud, but the concierge helped us settle in quickly—thank you!",
-    rating: 4.6,
-  },
-  {
-    id: "4",
-    receivedAt: "2024-10-04T19:37:00Z",
-    feedback: "Bathrooms were spotless and the new QR ordering flow was super easy to use.",
-    rating: 4.8,
-  },
-  {
-    id: "5",
-    receivedAt: "2024-10-03T11:58:00Z",
-    feedback: "Our conference room projector flickered a few times—could someone check the HDMI cable?",
-    rating: 3.7,
-  },
-  {
-    id: "6",
-    receivedAt: "2024-10-02T17:11:00Z",
-    feedback: "The new gluten-free pastries were a hit with our team. Please keep them on the menu!",
-    rating: 4.9,
-  },
-  {
-    id: "7",
-    receivedAt: "2024-10-01T09:22:00Z",
-    feedback: "Check-in was smooth, but the room thermostat seemed off by a few degrees overnight.",
-    rating: 4.1,
-  },
-  {
-    id: "8",
-    receivedAt: "2024-09-30T14:36:00Z",
-    feedback: "Appreciate the quick response on my lost item request—everything was handled perfectly.",
-    rating: 4.7,
-  },
-  {
-    id: "9",
-    receivedAt: "2024-09-29T10:29:00Z",
-    feedback: "The QR code took us to the survey instantly and the follow-up email felt very personalised.",
-    rating: 4.5,
-  },
-  {
-    id: "10",
-    receivedAt: "2024-09-28T15:55:00Z",
-    feedback: "Coffee refills slowed down after noon—maybe a dedicated barista during peak hours?",
-    rating: 3.8,
-  },
-];
-
 export default async function DashboardPage() {
   const user = await currentUser();
 
@@ -130,6 +29,13 @@ export default async function DashboardPage() {
     .catch(() => null);
 
   const businessName = business?.name ?? "Your business";
+  const dashboardData = business
+    ? await convex
+        .query(api.feedbacks.dashboardData, {
+          businessId: business._id,
+        })
+        .catch(() => null)
+    : null;
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950">
@@ -156,7 +62,7 @@ export default async function DashboardPage() {
             </p>
           </div>
           <div className="overflow-hidden rounded-[32px] border border-white/60 bg-white/70 shadow-xl backdrop-blur">
-            <StatsGrid />
+            <StatsGrid metrics={dashboardData?.metrics ?? []} />
           </div>
         </section>
 
@@ -172,7 +78,7 @@ export default async function DashboardPage() {
               </span>
             </div>
             <div className="mt-8 h-72 w-full">
-              <RatingTrendChart data={ratingsTrend} />
+              <RatingTrendChart data={dashboardData?.ratingTrend ?? []} />
             </div>
           </div>
 
@@ -187,7 +93,7 @@ export default async function DashboardPage() {
               </span>
             </div>
             <div className="mt-8 h-72 w-full">
-              <RatingDistributionChart data={ratingDistribution} />
+              <RatingDistributionChart data={dashboardData?.ratingDistribution ?? []} />
             </div>
           </div>
 
@@ -198,11 +104,11 @@ export default async function DashboardPage() {
                 <p className="text-sm text-slate-500">Explore the most recent feedback and spot shifts instantly</p>
               </div>
               <span className="inline-flex items-center rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-600">
-                {recentRatings.length} total ratings
+                {dashboardData?.recentRatings.length ?? 0} total ratings
               </span>
             </div>
             <div className="mt-8">
-              <RecentRatingsAreaChart ratings={recentRatings} />
+              <RecentRatingsAreaChart ratings={dashboardData?.recentRatings ?? []} />
             </div>
           </div>
 
@@ -213,11 +119,11 @@ export default async function DashboardPage() {
                 <p className="text-sm text-slate-500">Review individual comments, search by rating, and spot outliers fast</p>
               </div>
               <span className="inline-flex items-center rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-600">
-                {recentFeedback.length} feedback entries
+                {dashboardData?.recentFeedback.length ?? 0} feedback entries
               </span>
             </div>
             <div className="mt-8">
-              <RecentFeedbackTable feedback={recentFeedback} />
+              <RecentFeedbackTable feedback={dashboardData?.recentFeedback ?? []} />
             </div>
           </div>
         </section>

--- a/syncback/components/dashboard/RatingDistributionChart.tsx
+++ b/syncback/components/dashboard/RatingDistributionChart.tsx
@@ -30,6 +30,13 @@ const tooltipStyles: CSSProperties = {
 };
 
 export function RatingDistributionChart({ data }: RatingDistributionChartProps) {
+  const maxValue = data.reduce(
+    (currentMax, entry) =>
+      Number.isFinite(entry.value) ? Math.max(currentMax, entry.value) : currentMax,
+    0,
+  );
+  const domainMax = Math.max(10, Math.ceil((maxValue + 5) / 10) * 10);
+
   return (
     <ResponsiveContainer width="100%" height="100%">
       <RadarChart data={data} outerRadius="70%">
@@ -41,7 +48,12 @@ export function RatingDistributionChart({ data }: RatingDistributionChartProps) 
         </defs>
         <PolarGrid stroke="rgba(148, 163, 184, 0.35)" radialLines={false} />
         <PolarAngleAxis dataKey="segment" tick={{ fill: "#64748b", fontSize: 12 }} />
-        <PolarRadiusAxis angle={45} domain={[0, 70]} tickCount={5} tick={{ fill: "#94a3b8", fontSize: 11 }} />
+        <PolarRadiusAxis
+          angle={45}
+          domain={[0, domainMax]}
+          tickCount={5}
+          tick={{ fill: "#94a3b8", fontSize: 11 }}
+        />
         <Radar
           name="Ratings"
           dataKey="value"

--- a/syncback/components/dashboard/RatingTrendChart.tsx
+++ b/syncback/components/dashboard/RatingTrendChart.tsx
@@ -30,6 +30,26 @@ const tooltipStyles: CSSProperties = {
 };
 
 export function RatingTrendChart({ data }: RatingTrendChartProps) {
+  const averages = data
+    .map((datum) => (Number.isFinite(datum.average) ? datum.average : 0))
+    .filter((value) => Number.isFinite(value));
+  const minAverage = averages.length > 0 ? Math.min(...averages) : 0;
+  const maxAverage = averages.length > 0 ? Math.max(...averages) : 5;
+  const padding = 0.2;
+  let lowerBound = Math.max(0, Math.floor((minAverage - padding) * 10) / 10);
+  let upperBound = Math.min(5, Math.ceil((maxAverage + padding) * 10) / 10);
+
+  if (!Number.isFinite(lowerBound)) {
+    lowerBound = 0;
+  }
+  if (!Number.isFinite(upperBound) || upperBound <= lowerBound) {
+    upperBound = Math.min(5, lowerBound + 1);
+  }
+  if (upperBound === lowerBound) {
+    lowerBound = Math.max(0, lowerBound - 0.5);
+    upperBound = Math.min(5, upperBound + 0.5);
+  }
+
   return (
     <ResponsiveContainer width="100%" height="100%">
       <LineChart data={data} margin={{ top: 10, right: 20, left: -10, bottom: 0 }}>
@@ -42,7 +62,7 @@ export function RatingTrendChart({ data }: RatingTrendChartProps) {
         <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.35)" vertical={false} />
         <XAxis dataKey="month" tickLine={false} axisLine={false} tick={{ fill: "#64748b", fontSize: 12 }} />
         <YAxis
-          domain={[4, 5]}
+          domain={[lowerBound, upperBound]}
           tickLine={false}
           axisLine={false}
           tick={{ fill: "#64748b", fontSize: 12 }}

--- a/syncback/components/dashboard/StatsGrid.tsx
+++ b/syncback/components/dashboard/StatsGrid.tsx
@@ -28,14 +28,23 @@ type Metric = {
   diff: number;
 };
 
-const metrics: Metric[] = [
-  { title: "Average rating", icon: "rating", value: "4.7", diff: 8 },
-  { title: "5-star share", icon: "promoters", value: "62%", diff: 5 },
-  { title: "Feedback volume", icon: "volume", value: "284", diff: 18 },
-  { title: "Follow-up resolved", icon: "trends", value: "91%", diff: -4 },
-];
+type StatsGridProps = {
+  metrics: Metric[];
+};
 
-export function StatsGrid() {
+export function StatsGrid({ metrics }: StatsGridProps) {
+  if (metrics.length === 0) {
+    return (
+      <div className={classes.root}>
+        <Paper withBorder p="xl" radius="md" className={classes.card}>
+          <Text size="sm" c="dimmed">
+            Start collecting feedback to unlock live metrics.
+          </Text>
+        </Paper>
+      </div>
+    );
+  }
+
   const stats = metrics.map((stat) => {
     const Icon = icons[stat.icon];
     const DiffIcon = stat.diff >= 0 ? IconArrowUpRight : IconArrowDownRight;

--- a/syncback/convex/feedbacks.ts
+++ b/syncback/convex/feedbacks.ts
@@ -6,301 +6,336 @@ import type { Doc, Id } from "./_generated/dataModel";
 type FeedbackDoc = Doc<"feedbacks">;
 
 function averageRating(entries: FeedbackDoc[]) {
-  if (entries.length === 0) {
-    return 0;
-  }
+	if (entries.length === 0) {
+		return 0;
+	}
 
-  const total = entries.reduce((sum, entry) => sum + entry.rating, 0);
-  return total / entries.length;
+	const total = entries.reduce((sum, entry) => sum + entry.rating, 0);
+	return total / entries.length;
 }
 
-function percentageShare(entries: FeedbackDoc[], predicate: (entry: FeedbackDoc) => boolean) {
-  if (entries.length === 0) {
-    return 0;
-  }
+function percentageShare(
+	entries: FeedbackDoc[],
+	predicate: (entry: FeedbackDoc) => boolean
+) {
+	if (entries.length === 0) {
+		return 0;
+	}
 
-  const matches = entries.reduce((count, entry) => (predicate(entry) ? count + 1 : count), 0);
-  return (matches / entries.length) * 100;
+	const matches = entries.reduce(
+		(count, entry) => (predicate(entry) ? count + 1 : count),
+		0
+	);
+	return (matches / entries.length) * 100;
 }
 
-function percentChange(current: number, previous: number, { allowInfinity = false } = {}) {
-  if (Number.isNaN(current) || Number.isNaN(previous)) {
-    return 0;
-  }
+function percentChange(
+	current: number,
+	previous: number,
+	{ allowInfinity = false } = {}
+) {
+	if (Number.isNaN(current) || Number.isNaN(previous)) {
+		return 0;
+	}
 
-  if (previous === 0) {
-    if (!allowInfinity) {
-      return 0;
-    }
-    return current === 0 ? 0 : 100;
-  }
+	if (previous === 0) {
+		if (!allowInfinity) {
+			return 0;
+		}
+		return current === 0 ? 0 : 100;
+	}
 
-  return ((current - previous) / Math.abs(previous)) * 100;
+	return ((current - previous) / Math.abs(previous)) * 100;
 }
 
 async function fetchAllFeedback(ctx: QueryCtx, businessId: Id<"businesses">) {
-  const feedback: FeedbackDoc[] = [];
-  let cursor: string | undefined;
+	const feedback: FeedbackDoc[] = [];
 
-  while (true) {
-    const page = await ctx.db
-      .query("feedbacks")
-      .withIndex("by_businessId_createdAt", (q) => q.eq("businessId", businessId))
-      .order("desc")
-      .paginate(cursor ? { cursor, numItems: 200 } : { numItems: 200 });
+	let cursor: string | null = null;
 
-    feedback.push(...page.page);
+	while (true) {
+		const page = await ctx.db
+			.query("feedbacks")
+			.withIndex("by_businessId_createdAt", (q) =>
+				q.eq("businessId", businessId)
+			)
+			.order("desc")
+			.paginate({ cursor, numItems: 200 });
 
-    if (page.done) {
-      break;
-    }
+		feedback.push(...page.page);
 
-    cursor = page.continueCursor ?? undefined;
-  }
+		if (page.isDone) {
+			break;
+		}
 
-  return feedback;
+		cursor = page.continueCursor ?? undefined;
+	}
+
+	return feedback;
 }
 
 function toDateKey(timestamp: number) {
-  const date = new Date(timestamp);
-  const year = date.getUTCFullYear();
-  const month = `${date.getUTCMonth() + 1}`.padStart(2, "0");
-  const day = `${date.getUTCDate()}`.padStart(2, "0");
-  return `${year}-${month}-${day}`;
+	const date = new Date(timestamp);
+	const year = date.getUTCFullYear();
+	const month = `${date.getUTCMonth() + 1}`.padStart(2, "0");
+	const day = `${date.getUTCDate()}`.padStart(2, "0");
+	return `${year}-${month}-${day}`;
 }
 
 export const submit = mutation({
-  args: {
-    slug: v.string(),
-    rating: v.number(),
-    message: v.string(),
-    source: v.optional(v.union(v.literal("qr"), v.literal("link"), v.literal("kiosk"))),
-    ipHash: v.optional(v.string()),
-  },
-  handler: async (ctx, args) => {
-    if (args.rating < 0.5 || args.rating > 5) {
-      throw new Error("Rating must be between 0.5 and 5.");
-    }
+	args: {
+		slug: v.string(),
+		rating: v.number(),
+		message: v.string(),
+		source: v.optional(
+			v.union(v.literal("qr"), v.literal("link"), v.literal("kiosk"))
+		),
+		ipHash: v.optional(v.string()),
+	},
+	handler: async (ctx, args) => {
+		if (args.rating < 0.5 || args.rating > 5) {
+			throw new Error("Rating must be between 0.5 and 5.");
+		}
 
-    if (Math.abs(args.rating * 2 - Math.round(args.rating * 2)) > 1e-8) {
-      throw new Error("Rating must be provided in increments of 0.5 stars.");
-    }
+		if (Math.abs(args.rating * 2 - Math.round(args.rating * 2)) > 1e-8) {
+			throw new Error("Rating must be provided in increments of 0.5 stars.");
+		}
 
-    if (!args.message.trim()) {
-      throw new Error("Feedback message cannot be empty.");
-    }
+		if (!args.message.trim()) {
+			throw new Error("Feedback message cannot be empty.");
+		}
 
-    const business = await ctx.db
-      .query("businesses")
-      .withIndex("by_slug", (q) => q.eq("slug", args.slug))
-      .unique();
+		const business = await ctx.db
+			.query("businesses")
+			.withIndex("by_slug", (q) => q.eq("slug", args.slug))
+			.unique();
 
-    if (!business) {
-      throw new Error("Business not found.");
-    }
+		if (!business) {
+			throw new Error("Business not found.");
+		}
 
-    const timestamp = Date.now();
-    const feedbackId = await ctx.db.insert("feedbacks", {
-      businessId: business._id,
-      rating: args.rating,
-      message: args.message.trim(),
-      createdAt: timestamp,
-      status: "new",
-      source: args.source ?? "qr",
-      ipHash: args.ipHash,
-    });
+		const timestamp = Date.now();
+		const feedbackId = await ctx.db.insert("feedbacks", {
+			businessId: business._id,
+			rating: args.rating,
+			message: args.message.trim(),
+			createdAt: timestamp,
+			status: "new",
+			source: args.source ?? "qr",
+			ipHash: args.ipHash,
+		});
 
-    const dateKey = toDateKey(timestamp);
-    const existingAggregate = await ctx.db
-      .query("aggregates_daily")
-      .withIndex("by_businessId_date", (q) =>
-        q.eq("businessId", business._id).eq("date", dateKey),
-      )
-      .unique();
+		const dateKey = toDateKey(timestamp);
+		const existingAggregate = await ctx.db
+			.query("aggregates_daily")
+			.withIndex("by_businessId_date", (q) =>
+				q.eq("businessId", business._id).eq("date", dateKey)
+			)
+			.unique();
 
-    if (existingAggregate) {
-      const newCount = existingAggregate.count + 1;
-      const newAvg =
-        (existingAggregate.avgRating * existingAggregate.count + args.rating) /
-        newCount;
+		if (existingAggregate) {
+			const newCount = existingAggregate.count + 1;
+			const newAvg =
+				(existingAggregate.avgRating * existingAggregate.count + args.rating) /
+				newCount;
 
-      await ctx.db.patch(existingAggregate._id, {
-        count: newCount,
-        avgRating: newAvg,
-      });
-    } else {
-      await ctx.db.insert("aggregates_daily", {
-        businessId: business._id,
-        date: dateKey,
-        count: 1,
-        avgRating: args.rating,
-        createdAt: timestamp,
-      });
-    }
+			await ctx.db.patch(existingAggregate._id, {
+				count: newCount,
+				avgRating: newAvg,
+			});
+		} else {
+			await ctx.db.insert("aggregates_daily", {
+				businessId: business._id,
+				date: dateKey,
+				count: 1,
+				avgRating: args.rating,
+				createdAt: timestamp,
+			});
+		}
 
-    return { feedbackId };
-  },
+		return { feedbackId };
+	},
 });
 
 const monthFormatter = new Intl.DateTimeFormat("en-US", { month: "short" });
 
 export const dashboardData = query({
-  args: {
-    businessId: v.id("businesses"),
-  },
-  handler: async (ctx, args) => {
-    const allFeedback = await fetchAllFeedback(ctx, args.businessId);
+	args: {
+		businessId: v.id("businesses"),
+	},
+	handler: async (ctx, args) => {
+		const allFeedback = await fetchAllFeedback(ctx, args.businessId);
 
-    const now = Date.now();
-    const dayMs = 24 * 60 * 60 * 1000;
-    const periodMs = 30 * dayMs;
-    const currentPeriodStart = now - periodMs;
-    const previousPeriodStart = currentPeriodStart - periodMs;
+		const now = Date.now();
+		const dayMs = 24 * 60 * 60 * 1000;
+		const periodMs = 30 * dayMs;
+		const currentPeriodStart = now - periodMs;
+		const previousPeriodStart = currentPeriodStart - periodMs;
 
-    const currentFeedback = allFeedback.filter((entry) => entry.createdAt >= currentPeriodStart);
-    const previousFeedback = allFeedback.filter(
-      (entry) => entry.createdAt >= previousPeriodStart && entry.createdAt < currentPeriodStart,
-    );
+		const currentFeedback = allFeedback.filter(
+			(entry) => entry.createdAt >= currentPeriodStart
+		);
+		const previousFeedback = allFeedback.filter(
+			(entry) =>
+				entry.createdAt >= previousPeriodStart &&
+				entry.createdAt < currentPeriodStart
+		);
 
-    const ratingBucket = (rating: number) =>
-      Math.min(5, Math.max(1, Math.round(Number.isFinite(rating) ? rating : 0)));
+		const ratingBucket = (rating: number) =>
+			Math.min(
+				5,
+				Math.max(1, Math.round(Number.isFinite(rating) ? rating : 0))
+			);
 
-    const displayedAverageEntries = currentFeedback.length > 0 ? currentFeedback : allFeedback;
-    const displayedAverage = averageRating(displayedAverageEntries);
-    const currentAverage = averageRating(currentFeedback);
-    const previousAverage = averageRating(previousFeedback);
-    const averageDiff =
-      currentFeedback.length > 0 && previousFeedback.length > 0
-        ? percentChange(currentAverage, previousAverage)
-        : 0;
+		const displayedAverageEntries =
+			currentFeedback.length > 0 ? currentFeedback : allFeedback;
+		const displayedAverage = averageRating(displayedAverageEntries);
+		const currentAverage = averageRating(currentFeedback);
+		const previousAverage = averageRating(previousFeedback);
+		const averageDiff =
+			currentFeedback.length > 0 && previousFeedback.length > 0
+				? percentChange(currentAverage, previousAverage)
+				: 0;
 
-    const isFiveStar = (entry: FeedbackDoc) => ratingBucket(entry.rating) === 5;
-    const displayedFiveStarEntries = currentFeedback.length > 0 ? currentFeedback : allFeedback;
-    const displayedFiveStarShare = percentageShare(displayedFiveStarEntries, isFiveStar);
-    const currentFiveStarShare = percentageShare(currentFeedback, isFiveStar);
-    const previousFiveStarShare = percentageShare(previousFeedback, isFiveStar);
-    const fiveStarDiff =
-      currentFeedback.length > 0 && previousFeedback.length > 0
-        ? percentChange(currentFiveStarShare, previousFiveStarShare)
-        : 0;
+		const isFiveStar = (entry: FeedbackDoc) => ratingBucket(entry.rating) === 5;
+		const displayedFiveStarEntries =
+			currentFeedback.length > 0 ? currentFeedback : allFeedback;
+		const displayedFiveStarShare = percentageShare(
+			displayedFiveStarEntries,
+			isFiveStar
+		);
+		const currentFiveStarShare = percentageShare(currentFeedback, isFiveStar);
+		const previousFiveStarShare = percentageShare(previousFeedback, isFiveStar);
+		const fiveStarDiff =
+			currentFeedback.length > 0 && previousFeedback.length > 0
+				? percentChange(currentFiveStarShare, previousFiveStarShare)
+				: 0;
 
-    const isResolved = (entry: FeedbackDoc) => entry.status !== "new";
-    const displayedResolvedEntries = currentFeedback.length > 0 ? currentFeedback : allFeedback;
-    const displayedResolvedShare = percentageShare(displayedResolvedEntries, isResolved);
-    const currentResolvedShare = percentageShare(currentFeedback, isResolved);
-    const previousResolvedShare = percentageShare(previousFeedback, isResolved);
-    const resolvedDiff =
-      currentFeedback.length > 0 && previousFeedback.length > 0
-        ? percentChange(currentResolvedShare, previousResolvedShare)
-        : 0;
+		const isResolved = (entry: FeedbackDoc) => entry.status !== "new";
+		const displayedResolvedEntries =
+			currentFeedback.length > 0 ? currentFeedback : allFeedback;
+		const displayedResolvedShare = percentageShare(
+			displayedResolvedEntries,
+			isResolved
+		);
+		const currentResolvedShare = percentageShare(currentFeedback, isResolved);
+		const previousResolvedShare = percentageShare(previousFeedback, isResolved);
+		const resolvedDiff =
+			currentFeedback.length > 0 && previousFeedback.length > 0
+				? percentChange(currentResolvedShare, previousResolvedShare)
+				: 0;
 
-    const currentVolume = currentFeedback.length;
-    const displayedVolume = currentVolume > 0 ? currentVolume : allFeedback.length;
-    const volumeDiff =
-      currentVolume > 0
-        ? percentChange(currentVolume, previousFeedback.length, { allowInfinity: true })
-        : 0;
+		const currentVolume = currentFeedback.length;
+		const displayedVolume =
+			currentVolume > 0 ? currentVolume : allFeedback.length;
+		const volumeDiff =
+			currentVolume > 0
+				? percentChange(currentVolume, previousFeedback.length, {
+						allowInfinity: true,
+					})
+				: 0;
 
-    const metrics =
-      allFeedback.length === 0
-        ? []
-        : [
-            {
-              title: "Average rating",
-              icon: "rating" as const,
-              value: displayedAverage.toFixed(2),
-              diff: Math.round(averageDiff),
-            },
-            {
-              title: "5-star share",
-              icon: "promoters" as const,
-              value: `${Math.round(displayedFiveStarShare)}%`,
-              diff: Math.round(fiveStarDiff),
-            },
-            {
-              title: "Feedback volume",
-              icon: "volume" as const,
-              value: displayedVolume.toString(),
-              diff: Math.round(volumeDiff),
-            },
-            {
-              title: "Follow-up resolved",
-              icon: "trends" as const,
-              value: `${Math.round(displayedResolvedShare)}%`,
-              diff: Math.round(resolvedDiff),
-            },
-          ];
+		const metrics =
+			allFeedback.length === 0
+				? []
+				: [
+						{
+							title: "Average rating",
+							icon: "rating" as const,
+							value: displayedAverage.toFixed(2),
+							diff: Math.round(averageDiff),
+						},
+						{
+							title: "5-star share",
+							icon: "promoters" as const,
+							value: `${Math.round(displayedFiveStarShare)}%`,
+							diff: Math.round(fiveStarDiff),
+						},
+						{
+							title: "Feedback volume",
+							icon: "volume" as const,
+							value: displayedVolume.toString(),
+							diff: Math.round(volumeDiff),
+						},
+						{
+							title: "Follow-up resolved",
+							icon: "trends" as const,
+							value: `${Math.round(displayedResolvedShare)}%`,
+							diff: Math.round(resolvedDiff),
+						},
+					];
 
-    const monthsToShow = 6;
-    const monthBuckets = new Map<string, { sum: number; count: number }>();
-    for (const entry of allFeedback) {
-      const date = new Date(entry.createdAt);
-      const key = `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
-      const bucket = monthBuckets.get(key) ?? { sum: 0, count: 0 };
-      bucket.sum += entry.rating;
-      bucket.count += 1;
-      monthBuckets.set(key, bucket);
-    }
+		const monthsToShow = 6;
+		const monthBuckets = new Map<string, { sum: number; count: number }>();
+		for (const entry of allFeedback) {
+			const date = new Date(entry.createdAt);
+			const key = `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+			const bucket = monthBuckets.get(key) ?? { sum: 0, count: 0 };
+			bucket.sum += entry.rating;
+			bucket.count += 1;
+			monthBuckets.set(key, bucket);
+		}
 
-    const trendMonths: { label: string; key: string }[] = [];
-    const currentMonth = new Date();
-    for (let index = monthsToShow - 1; index >= 0; index -= 1) {
-      const date = new Date(
-        Date.UTC(
-          currentMonth.getUTCFullYear(),
-          currentMonth.getUTCMonth() - index,
-          1,
-          0,
-          0,
-          0,
-        ),
-      );
-      const key = `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
-      trendMonths.push({ label: monthFormatter.format(date), key });
-    }
+		const trendMonths: { label: string; key: string }[] = [];
+		const currentMonth = new Date();
+		for (let index = monthsToShow - 1; index >= 0; index -= 1) {
+			const date = new Date(
+				Date.UTC(
+					currentMonth.getUTCFullYear(),
+					currentMonth.getUTCMonth() - index,
+					1,
+					0,
+					0,
+					0
+				)
+			);
+			const key = `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+			trendMonths.push({ label: monthFormatter.format(date), key });
+		}
 
-    const ratingTrend = trendMonths.map(({ key, label }) => {
-      const bucket = monthBuckets.get(key);
-      const average = bucket && bucket.count > 0 ? bucket.sum / bucket.count : 0;
-      return { month: label, average: Math.round(average * 100) / 100 };
-    });
+		const ratingTrend = trendMonths.map(({ key, label }) => {
+			const bucket = monthBuckets.get(key);
+			const average =
+				bucket && bucket.count > 0 ? bucket.sum / bucket.count : 0;
+			return { month: label, average: Math.round(average * 100) / 100 };
+		});
 
-    const distributionCounts = [0, 0, 0, 0, 0, 0];
-    for (const entry of allFeedback) {
-      const bucket = ratingBucket(entry.rating);
-      distributionCounts[bucket] += 1;
-    }
+		const distributionCounts = [0, 0, 0, 0, 0, 0];
+		for (const entry of allFeedback) {
+			const bucket = ratingBucket(entry.rating);
+			distributionCounts[bucket] += 1;
+		}
 
-    const totalFeedback = allFeedback.length;
-    const ratingDistribution = [1, 2, 3, 4, 5].map((stars) => ({
-      segment: `${stars} Star${stars === 1 ? "" : "s"}`,
-      value:
-        totalFeedback === 0
-          ? 0
-          : Math.round((distributionCounts[stars] / totalFeedback) * 100),
-    }));
+		const totalFeedback = allFeedback.length;
+		const ratingDistribution = [1, 2, 3, 4, 5].map((stars) => ({
+			segment: `${stars} Star${stars === 1 ? "" : "s"}`,
+			value:
+				totalFeedback === 0
+					? 0
+					: Math.round((distributionCounts[stars] / totalFeedback) * 100),
+		}));
 
-    const recentRatings = [...allFeedback]
-      .reverse()
-      .map((entry) => ({
-        rating: entry.rating,
-        receivedAt: new Date(entry.createdAt).toISOString(),
-      }));
+		const recentRatings = [...allFeedback].reverse().map((entry) => ({
+			rating: entry.rating,
+			receivedAt: new Date(entry.createdAt).toISOString(),
+		}));
 
-    const maxFeedbackEntries = 200;
-    const recentFeedback = allFeedback.slice(0, maxFeedbackEntries).map((entry) => ({
-      id: String(entry._id),
-      receivedAt: new Date(entry.createdAt).toISOString(),
-      feedback: entry.message,
-      rating: entry.rating,
-    }));
+		const maxFeedbackEntries = 200;
+		const recentFeedback = allFeedback
+			.slice(0, maxFeedbackEntries)
+			.map((entry) => ({
+				id: String(entry._id),
+				receivedAt: new Date(entry.createdAt).toISOString(),
+				feedback: entry.message,
+				rating: entry.rating,
+			}));
 
-    return {
-      metrics,
-      ratingTrend,
-      ratingDistribution,
-      recentRatings,
-      recentFeedback,
-    };
-  },
+		return {
+			metrics,
+			ratingTrend,
+			ratingDistribution,
+			recentRatings,
+			recentFeedback,
+		};
+	},
 });

--- a/syncback/convex/feedbacks.ts
+++ b/syncback/convex/feedbacks.ts
@@ -47,7 +47,7 @@ async function fetchAllFeedback(ctx: QueryCtx, businessId: Id<"businesses">) {
       .query("feedbacks")
       .withIndex("by_businessId_createdAt", (q) => q.eq("businessId", businessId))
       .order("desc")
-      .paginate({ initialNumItems: 200, cursor });
+      .paginate(cursor ? { cursor, numItems: 200 } : { numItems: 200 });
 
     feedback.push(...page.page);
 

--- a/syncback/convex/feedbacks.ts
+++ b/syncback/convex/feedbacks.ts
@@ -47,9 +47,7 @@ async function fetchAllFeedback(ctx: QueryCtx, businessId: Id<"businesses">) {
       .query("feedbacks")
       .withIndex("by_businessId_createdAt", (q) => q.eq("businessId", businessId))
       .order("desc")
-      .paginate(
-        cursor ? { cursor, numItems: 200 } : { initialNumItems: 200 },
-      );
+      .paginate({ initialNumItems: 200, cursor });
 
     feedback.push(...page.page);
 


### PR DESCRIPTION
## Summary
- fetch dashboard metrics, charts, and tables from Convex instead of hardcoded arrays
- expose a Convex dashboardData query that aggregates feedback stats, trends, and recent entries
- adapt dashboard widgets to consume dynamic data with responsive axes and empty-state handling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd92c38924832b8ae0c873d3a4d8be