### PR TITLE
Fix pagination cursor handling in feedback dashboard query

### DIFF
--- a/syncback/convex/feedbacks.ts
+++ b/syncback/convex/feedbacks.ts
@@ -47,7 +47,9 @@ async function fetchAllFeedback(ctx: QueryCtx, businessId: Id<"businesses">) {
       .query("feedbacks")
       .withIndex("by_businessId_createdAt", (q) => q.eq("businessId", businessId))
       .order("desc")
-      .paginate({ initialNumItems: 200, cursor });
+      .paginate(
+        cursor ? { cursor, numItems: 200 } : { initialNumItems: 200 },
+      );
 
     feedback.push(...page.page);
 


### PR DESCRIPTION
## Summary
- fix Convex feedback pagination to request numItems when continuing with a cursor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd95c3d59c832bb2b37d2872ee759e