### PR TITLE
Add global dark mode toggle to navigation

### DIFF
--- a/syncback/app/(dashboard)/dashboard/page.tsx
+++ b/syncback/app/(dashboard)/dashboard/page.tsx
@@ -40,7 +40,7 @@ export default async function DashboardPage() {
     : null;
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950">
+    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950 dark:bg-slate-950 dark:text-slate-100">
       <HeaderMegaMenu />
       <PageBackground>
         <div className="absolute left-1/2 top-[-8%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(59,130,246,0.22),_rgba(255,255,255,0))] blur-3xl" />

--- a/syncback/app/(dashboard)/dashboard/sections/PerformanceOverviewSection.tsx
+++ b/syncback/app/(dashboard)/dashboard/sections/PerformanceOverviewSection.tsx
@@ -10,13 +10,13 @@ export function PerformanceOverviewSection({ businessName, metrics }: Performanc
   return (
     <section className="space-y-6">
       <div className="space-y-2">
-        <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500">Performance overview</p>
-        <h1 className="text-3xl font-semibold leading-tight text-slate-950 sm:text-4xl lg:text-5xl">Insights for {businessName}</h1>
-        <p className="max-w-2xl text-base text-slate-600 sm:text-lg">
+        <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">Performance overview</p>
+        <h1 className="text-3xl font-semibold leading-tight text-slate-950 dark:text-slate-100 sm:text-4xl lg:text-5xl">Insights for {businessName}</h1>
+        <p className="max-w-2xl text-base text-slate-600 dark:text-slate-300 sm:text-lg">
           Track how guests feel about every experience and spot momentum in your ratings at a glance.
         </p>
       </div>
-      <div className="overflow-hidden rounded-[32px] border border-white/60 bg-white/70 shadow-xl backdrop-blur">
+      <div className="overflow-hidden rounded-[32px] border border-white/60 bg-white/70 shadow-xl backdrop-blur dark:border-slate-700 dark:bg-slate-900/60 dark:shadow-slate-900/40">
         <StatsGrid metrics={metrics} />
       </div>
     </section>

--- a/syncback/app/(dashboard)/dashboard/sections/PerformanceOverviewSection.tsx
+++ b/syncback/app/(dashboard)/dashboard/sections/PerformanceOverviewSection.tsx
@@ -16,7 +16,7 @@ export function PerformanceOverviewSection({ businessName, metrics }: Performanc
           Track how guests feel about every experience and spot momentum in your ratings at a glance.
         </p>
       </div>
-      <div className="overflow-hidden rounded-[32px] border border-white/60 bg-white/70 shadow-xl backdrop-blur dark:border-slate-700 dark:bg-slate-900/60 dark:shadow-slate-900/40">
+      <div className="overflow-hidden rounded-[32px] border border-white/60 bg-white/70 shadow-xl backdrop-blur dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
         <StatsGrid metrics={metrics} />
       </div>
     </section>

--- a/syncback/app/(dashboard)/dashboard/sections/RatingDistributionSection.tsx
+++ b/syncback/app/(dashboard)/dashboard/sections/RatingDistributionSection.tsx
@@ -7,13 +7,13 @@ export type RatingDistributionSectionProps = {
 
 export function RatingDistributionSection({ data }: RatingDistributionSectionProps) {
   return (
-    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl">
+    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-xl font-semibold text-slate-900">Rating distribution</h2>
-          <p className="text-sm text-slate-500">Share of responses by star level</p>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Rating distribution</h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400">Share of responses by star level</p>
         </div>
-        <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-600">Updated hourly</span>
+        <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-300">Updated hourly</span>
       </div>
       <div className="mt-8 h-72 w-full">
         <RatingDistributionChart data={data} />

--- a/syncback/app/(dashboard)/dashboard/sections/RatingTrendSection.tsx
+++ b/syncback/app/(dashboard)/dashboard/sections/RatingTrendSection.tsx
@@ -7,13 +7,13 @@ export type RatingTrendSectionProps = {
 
 export function RatingTrendSection({ data }: RatingTrendSectionProps) {
   return (
-    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl">
+    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-xl font-semibold text-slate-900">Rating trend</h2>
-          <p className="text-sm text-slate-500">Trailing six months of average guest ratings</p>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Rating trend</h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400">Trailing six months of average guest ratings</p>
         </div>
-        <span className="rounded-full bg-sky-500/10 px-3 py-1 text-xs font-medium text-sky-600">Live sync</span>
+        <span className="rounded-full bg-sky-500/10 px-3 py-1 text-xs font-medium text-sky-600 dark:bg-sky-500/20 dark:text-sky-300">Live sync</span>
       </div>
       <div className="mt-8 h-72 w-full">
         <RatingTrendChart data={data} />

--- a/syncback/app/(dashboard)/dashboard/sections/RecentFeedbackSection.tsx
+++ b/syncback/app/(dashboard)/dashboard/sections/RecentFeedbackSection.tsx
@@ -8,13 +8,13 @@ export type RecentFeedbackSectionProps = {
 
 export function RecentFeedbackSection({ feedback, totalCount }: RecentFeedbackSectionProps) {
   return (
-    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl lg:col-span-2">
+    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl lg:col-span-2 dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h2 className="text-xl font-semibold text-slate-900">Feedback details</h2>
-          <p className="text-sm text-slate-500">Review individual comments, search by rating, and spot outliers fast</p>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Feedback details</h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400">Review individual comments, search by rating, and spot outliers fast</p>
         </div>
-        <span className="inline-flex items-center rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-600">
+        <span className="inline-flex items-center rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-sky-500/10 dark:text-sky-300">
           {totalCount} feedback entries
         </span>
       </div>

--- a/syncback/app/(dashboard)/dashboard/sections/RecentRatingsSection.tsx
+++ b/syncback/app/(dashboard)/dashboard/sections/RecentRatingsSection.tsx
@@ -8,13 +8,13 @@ export type RecentRatingsSectionProps = {
 
 export function RecentRatingsSection({ ratings, totalCount }: RecentRatingsSectionProps) {
   return (
-    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl lg:col-span-2">
+    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl lg:col-span-2 dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h2 className="text-xl font-semibold text-slate-900">Recent ratings</h2>
-          <p className="text-sm text-slate-500">Explore the most recent feedback and spot shifts instantly</p>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Recent ratings</h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400">Explore the most recent feedback and spot shifts instantly</p>
         </div>
-        <span className="inline-flex items-center rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-600">
+        <span className="inline-flex items-center rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-sky-500/10 dark:text-sky-300">
           {totalCount} total ratings
         </span>
       </div>

--- a/syncback/app/(dashboard)/settings/page.tsx
+++ b/syncback/app/(dashboard)/settings/page.tsx
@@ -41,7 +41,7 @@ export default async function SettingsPage() {
   };
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950">
+    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950 dark:bg-slate-950 dark:text-slate-100">
       <HeaderMegaMenu />
       <PageBackground>
         <div className="absolute left-1/2 top-[-8%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(59,130,246,0.22),_rgba(255,255,255,0))] blur-3xl" />

--- a/syncback/app/(dashboard)/settings/sections/SettingsIntroSection.tsx
+++ b/syncback/app/(dashboard)/settings/sections/SettingsIntroSection.tsx
@@ -22,15 +22,15 @@ export function SettingsIntroSection() {
   return (
     <section className="grid gap-10 lg:grid-cols-[minmax(0,_1.05fr)_minmax(0,_0.95fr)] lg:items-center">
       <div className="space-y-7">
-        <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm backdrop-blur">
+        <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-200">
           <Sparkles className="h-4 w-4 text-sky-500" aria-hidden />
           Craft your feedback hub
         </span>
         <div className="space-y-4">
-          <h1 className="text-3xl font-semibold leading-tight text-slate-950 sm:text-4xl lg:text-5xl">
+          <h1 className="text-3xl font-semibold leading-tight text-slate-950 dark:text-slate-100 sm:text-4xl lg:text-5xl">
             Set up a beautiful QR-powered page for collecting guest feedback
           </h1>
-          <p className="max-w-xl text-base text-slate-600 sm:text-lg">
+          <p className="max-w-xl text-base text-slate-600 dark:text-slate-300 sm:text-lg">
             Add your business details once and we&rsquo;ll generate a shareable QR card plus a magic link that guides every guest back to your private feedback form.
           </p>
         </div>
@@ -39,30 +39,30 @@ export function SettingsIntroSection() {
           {highlights.map(({ icon: Icon, title, description }) => (
             <li
               key={title}
-              className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-lg"
+              className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-lg dark:border-slate-700 dark:bg-slate-800/70 dark:hover:shadow-slate-900/50"
             >
               <div className="flex items-center gap-3">
                 <div className="flex h-10 w-10 items-center justify-center rounded-full bg-sky-500/10 text-sky-600">
                   <Icon className="h-5 w-5" aria-hidden />
                 </div>
-                <h3 className="text-base font-semibold text-slate-900">{title}</h3>
+                <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">{title}</h3>
               </div>
-              <p className="mt-3 text-sm text-slate-600">{description}</p>
+              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{description}</p>
             </li>
           ))}
         </ul>
       </div>
 
       <div className="relative order-first flex items-center justify-center lg:order-last">
-        <div className="relative w-full max-w-md rounded-[32px] border border-white/70 bg-white/70 p-8 shadow-xl backdrop-blur">
+        <div className="relative w-full max-w-md rounded-[32px] border border-white/70 bg-white/70 p-8 shadow-xl backdrop-blur dark:border-slate-700 dark:bg-slate-900/60 dark:shadow-slate-900/40">
           <div className="absolute -left-6 top-8 hidden h-20 w-20 rounded-full bg-gradient-to-br from-sky-400/40 to-blue-500/10 blur-xl lg:block" />
           <div className="absolute -right-6 bottom-8 hidden h-24 w-24 rounded-full bg-gradient-to-br from-emerald-400/40 to-emerald-500/10 blur-xl lg:block" />
           <div className="relative flex flex-col items-center gap-5 text-center">
             <div className="rounded-full bg-sky-500/10 p-3 text-sky-600">
               <QrCode className="h-6 w-6" aria-hidden />
             </div>
-            <h2 className="text-xl font-semibold text-slate-900">Drop your details, receive a branded QR card</h2>
-            <p className="text-sm text-slate-600">
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Drop your details, receive a branded QR card</h2>
+            <p className="text-sm text-slate-600 dark:text-slate-300">
               Perfect for tabletops, checkout counters, event lanyards—wherever your guests linger.
             </p>
           </div>

--- a/syncback/app/layout.tsx
+++ b/syncback/app/layout.tsx
@@ -23,11 +23,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" data-mantine-color-scheme="light">
+    <html lang="en" data-mantine-color-scheme="light" suppressHydrationWarning>
       <head>
         <ColorSchemeScript defaultColorScheme="light" />
       </head>
-      <body className={`${poppins.className} antialiased`}>
+      <body className={`${poppins.className} antialiased`} suppressHydrationWarning>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/syncback/app/page.tsx
+++ b/syncback/app/page.tsx
@@ -84,7 +84,7 @@ export default function Home() {
   }, []);
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950">
+    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950 dark:bg-slate-950 dark:text-slate-100">
       <HeaderMegaMenu />
       <PageBackground gridClassName="opacity-50" noiseClassName="opacity-40 mix-blend-soft-light">
         <div className="absolute left-1/2 top-[-10%] h-[520px] w-[520px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(59,130,246,0.28),_rgba(255,255,255,0))] blur-3xl" />

--- a/syncback/app/providers.tsx
+++ b/syncback/app/providers.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { ClerkProvider } from "@clerk/nextjs";
-import { MantineProvider } from "@mantine/core";
 import type { ReactNode } from "react";
+
+import { ThemeProvider } from "@/lib/theme-context";
 
 type ProvidersProps = {
   children: ReactNode;
@@ -11,7 +12,7 @@ type ProvidersProps = {
 export function Providers({ children }: ProvidersProps) {
   return (
     <ClerkProvider>
-      <MantineProvider defaultColorScheme="light">{children}</MantineProvider>
+      <ThemeProvider>{children}</ThemeProvider>
     </ClerkProvider>
   );
 }

--- a/syncback/components/dashboard/RatingDistributionChart.tsx
+++ b/syncback/components/dashboard/RatingDistributionChart.tsx
@@ -38,7 +38,7 @@ export function RatingDistributionChart({ data }: RatingDistributionChartProps) 
   const domainMax = Math.max(10, Math.ceil((maxValue + 5) / 10) * 10);
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
+    <ResponsiveContainer width="100%" height="100%" className="text-slate-500 dark:text-slate-300">
       <RadarChart data={data} outerRadius="70%">
         <defs>
           <linearGradient id="radarGradient" x1="0" y1="0" x2="1" y2="1">
@@ -46,13 +46,13 @@ export function RatingDistributionChart({ data }: RatingDistributionChartProps) 
             <stop offset="100%" stopColor="#22d3ee" stopOpacity={0.4} />
           </linearGradient>
         </defs>
-        <PolarGrid stroke="rgba(148, 163, 184, 0.35)" radialLines={false} />
-        <PolarAngleAxis dataKey="segment" tick={{ fill: "#64748b", fontSize: 12 }} />
+        <PolarGrid stroke="currentColor" strokeOpacity={0.25} radialLines={false} />
+        <PolarAngleAxis dataKey="segment" tick={{ fill: "currentColor", fontSize: 12 }} />
         <PolarRadiusAxis
           angle={45}
           domain={[0, domainMax]}
           tickCount={5}
-          tick={{ fill: "#94a3b8", fontSize: 11 }}
+          tick={{ fill: "currentColor", fontSize: 11 }}
         />
         <Radar
           name="Ratings"

--- a/syncback/components/dashboard/RatingTrendChart.tsx
+++ b/syncback/components/dashboard/RatingTrendChart.tsx
@@ -51,7 +51,7 @@ export function RatingTrendChart({ data }: RatingTrendChartProps) {
   }
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
+    <ResponsiveContainer width="100%" height="100%" className="text-slate-500 dark:text-slate-300">
       <LineChart data={data} margin={{ top: 10, right: 20, left: -10, bottom: 0 }}>
         <defs>
           <linearGradient id="lineGradient" x1="0" y1="0" x2="0" y2="1">
@@ -59,13 +59,13 @@ export function RatingTrendChart({ data }: RatingTrendChartProps) {
             <stop offset="95%" stopColor="#0ea5e9" stopOpacity={0.1} />
           </linearGradient>
         </defs>
-        <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.35)" vertical={false} />
-        <XAxis dataKey="month" tickLine={false} axisLine={false} tick={{ fill: "#64748b", fontSize: 12 }} />
+        <CartesianGrid strokeDasharray="4 8" stroke="currentColor" strokeOpacity={0.25} vertical={false} />
+        <XAxis dataKey="month" tickLine={false} axisLine={false} tick={{ fill: "currentColor", fontSize: 12 }} />
         <YAxis
           domain={[lowerBound, upperBound]}
           tickLine={false}
           axisLine={false}
-          tick={{ fill: "#64748b", fontSize: 12 }}
+          tick={{ fill: "currentColor", fontSize: 12 }}
           allowDecimals
         />
         <Tooltip

--- a/syncback/components/dashboard/RecentFeedbackTable.tsx
+++ b/syncback/components/dashboard/RecentFeedbackTable.tsx
@@ -94,7 +94,7 @@ const columns: ColumnDef<FeedbackEntry>[] = [
     cell: ({ row }) => {
       const timestamp = row.getValue<string>("receivedAt");
       return (
-        <span className="text-sm text-slate-600">
+        <span className="text-sm text-slate-600 dark:text-slate-300">
           {dateFormatter.format(new Date(timestamp))}
         </span>
       );
@@ -127,7 +127,7 @@ const columns: ColumnDef<FeedbackEntry>[] = [
     header: "Feedback",
     accessorKey: "feedback",
     cell: ({ row }) => (
-      <p className="text-sm text-slate-700">{row.getValue("feedback")}</p>
+      <p className="text-sm text-slate-700 dark:text-slate-200">{row.getValue("feedback")}</p>
     ),
     meta: {
       filterVariant: "text",
@@ -376,7 +376,7 @@ function Filter({ column }: { column: Column<FeedbackEntry, unknown> }) {
             column.setFilterValue(value === "all" ? undefined : value);
           }}
         >
-          <SelectTrigger id={`${id}-select`}>
+          <SelectTrigger id={`${id}-select`} className="dark:border-slate-700/80 dark:bg-slate-900/60 dark:text-slate-200">
             <SelectValue placeholder="All ratings" />
           </SelectTrigger>
           <SelectContent>
@@ -407,15 +407,15 @@ function Filter({ column }: { column: Column<FeedbackEntry, unknown> }) {
               id={`${id}-date-trigger`}
               onClick={() => setIsCalendarOpen((open) => !open)}
               className={cn(
-                "inline-flex w-full items-center justify-between gap-2 rounded-xl border border-slate-200/80 bg-white px-3 py-2 text-left text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-300 hover:text-slate-900",
+                "inline-flex w-full items-center justify-between gap-2 rounded-xl border border-slate-200/80 bg-white px-3 py-2 text-left text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-300 hover:text-slate-900 dark:border-slate-700/80 dark:bg-slate-900/60 dark:text-slate-300 dark:hover:border-slate-600 dark:hover:text-slate-100",
                 hasSelection && "text-slate-900",
               )}
             >
               <span className="inline-flex items-center gap-2">
-                <CalendarIcon className="size-4 text-slate-400" aria-hidden="true" />
+                <CalendarIcon className="size-4 text-slate-400 dark:text-slate-500" aria-hidden="true" />
                 {label}
               </span>
-              <ChevronDownIcon className="size-4 text-slate-400" aria-hidden="true" />
+              <ChevronDownIcon className="size-4 text-slate-400 dark:text-slate-500" aria-hidden="true" />
             </button>
             {hasSelection ? (
               <button
@@ -424,7 +424,7 @@ function Filter({ column }: { column: Column<FeedbackEntry, unknown> }) {
                   column.setFilterValue(undefined);
                   setIsCalendarOpen(false);
                 }}
-                className="inline-flex items-center rounded-xl border border-transparent bg-slate-100 px-3 py-2 text-xs font-semibold text-slate-500 transition hover:bg-slate-200 hover:text-slate-700"
+                className="inline-flex items-center rounded-xl border border-transparent bg-slate-100 px-3 py-2 text-xs font-semibold text-slate-500 transition hover:bg-slate-200 hover:text-slate-700 dark:bg-slate-800/70 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-100"
               >
                 Clear
               </button>
@@ -432,7 +432,7 @@ function Filter({ column }: { column: Column<FeedbackEntry, unknown> }) {
           </div>
           {isCalendarOpen ? (
             <div className="absolute left-0 top-full z-50 mt-2 min-w-[18rem]">
-              <div className="origin-top overflow-hidden rounded-[28px] border border-slate-200/70 bg-white/95 p-3 shadow-xl">
+              <div className="origin-top overflow-hidden rounded-[28px] border border-slate-200/70 bg-white/95 p-3 shadow-xl dark:border-slate-700/70 dark:bg-slate-900/90 dark:shadow-slate-900/40">
                 <RangeCalendar
                   value={dateRangeValue}
                   onChange={(value) => {
@@ -456,7 +456,7 @@ function Filter({ column }: { column: Column<FeedbackEntry, unknown> }) {
       <div className="relative">
         <Input
           id={`${id}-input`}
-          className="peer ps-9"
+          className="peer ps-9 dark:border-slate-700/80 dark:bg-slate-900/60 dark:text-slate-200"
           value={(columnFilterValue ?? "") as string}
           onChange={(event) => column.setFilterValue(event.target.value)}
           placeholder={
@@ -465,7 +465,7 @@ function Filter({ column }: { column: Column<FeedbackEntry, unknown> }) {
           }
           type="text"
         />
-        <div className="pointer-events-none absolute inset-y-0 start-0 flex items-center justify-center ps-3 text-muted-foreground/80">
+        <div className="pointer-events-none absolute inset-y-0 start-0 flex items-center justify-center ps-3 text-muted-foreground/80 dark:text-slate-500">
           <SearchIcon size={16} />
         </div>
       </div>
@@ -526,16 +526,16 @@ function FeedbackDetailModal({
       <div className="flex flex-col gap-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400 dark:text-slate-500">
               Received on
             </p>
-            <p className="text-xl font-semibold text-slate-900">
+            <p className="text-xl font-semibold text-slate-900 dark:text-slate-100">
               {formattedDate}
             </p>
           </div>
           <div className="flex flex-col items-start gap-3 sm:items-end">
             <div className="space-y-1 text-left sm:text-right">
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400 dark:text-slate-500">
                 Rating
               </p>
               <div className="inline-flex items-center gap-3 rounded-full border border-amber-200/70 bg-amber-50/80 px-4 py-2 shadow-inner">
@@ -549,15 +549,15 @@ function FeedbackDetailModal({
                 />
               </div>
             </div>
-            <div className="flex items-center gap-2 text-sm text-slate-500">
+            <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
               <StarRating rating={entry.rating} />
               <span>{entry.rating.toFixed(1)} of 5 stars</span>
             </div>
           </div>
         </div>
 
-        <div className="rounded-3xl border border-slate-200/70 bg-white/90 p-6 shadow-inner">
-          <p className="text-base leading-relaxed text-slate-700">{entry.feedback}</p>
+        <div className="rounded-3xl border border-slate-200/70 bg-white/90 p-6 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/70 dark:shadow-slate-900/40">
+          <p className="text-base leading-relaxed text-slate-700 dark:text-slate-200">{entry.feedback}</p>
         </div>
       </div>
     </BasicModal>

--- a/syncback/components/dashboard/RecentRatingsAreaChart.tsx
+++ b/syncback/components/dashboard/RecentRatingsAreaChart.tsx
@@ -106,7 +106,7 @@ export function RecentRatingsAreaChart({
 
   if (!hasRatings) {
     return (
-      <div className="flex h-full min-h-[18rem] flex-col items-center justify-center rounded-[32px] border border-dashed border-slate-200 bg-white/70 p-8 text-center text-sm text-slate-500">
+      <div className="flex h-full min-h-[18rem] flex-col items-center justify-center rounded-[32px] border border-dashed border-slate-200 bg-white/70 p-8 text-center text-sm text-slate-500 dark:border-slate-700/80 dark:bg-slate-900/60 dark:text-slate-300">
         <p>No ratings have been collected yet. Share your feedback link to start seeing momentum here.</p>
       </div>
     );
@@ -115,9 +115,9 @@ export function RecentRatingsAreaChart({
   return (
     <div className="flex h-full flex-col gap-8">
       <div className="flex flex-col gap-2">
-        <Label htmlFor="ratings-window" className="flex items-center justify-between text-slate-700">
+        <Label htmlFor="ratings-window" className="flex items-center justify-between text-slate-700 dark:text-slate-200">
           <span>Last {windowSize} ratings</span>
-          <span className="text-xs font-medium text-slate-400">Average {averageRating.toFixed(2)} ★</span>
+          <span className="text-xs font-medium text-slate-400 dark:text-slate-500">Average {averageRating.toFixed(2)} ★</span>
         </Label>
         <div>
           <Slider
@@ -131,7 +131,7 @@ export function RecentRatingsAreaChart({
             aria-label="Select the number of recent ratings to display"
           />
           <span
-            className="mt-3 flex w-full items-center justify-between gap-1 px-2.5 text-xs font-medium text-slate-400"
+            className="mt-3 flex w-full items-center justify-between gap-1 px-2.5 text-xs font-medium text-slate-400 dark:text-slate-500"
             aria-hidden="true"
           >
             {ticks.map((tick, index) => {
@@ -141,7 +141,7 @@ export function RecentRatingsAreaChart({
                 <span key={tick} className="flex w-0 flex-col items-center justify-center gap-2">
                   <span
                     className={cn(
-                      "bg-slate-400/70 h-1 w-px",
+                      "h-1 w-px bg-slate-400/70 dark:bg-slate-600/60",
                       !showLabel && "h-0.5",
                     )}
                   />
@@ -153,7 +153,7 @@ export function RecentRatingsAreaChart({
         </div>
       </div>
 
-      <div className="h-72 w-full">
+      <div className="h-72 w-full text-slate-500 dark:text-slate-300">
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart data={chartData} margin={{ top: 10, right: 20, left: -10, bottom: 0 }}>
             <defs>
@@ -162,9 +162,21 @@ export function RecentRatingsAreaChart({
                 <stop offset="95%" stopColor="#0ea5e9" stopOpacity={0.05} />
               </linearGradient>
             </defs>
-            <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.35)" vertical={false} />
-            <XAxis dataKey="label" tickLine={false} axisLine={false} tick={{ fill: "#64748b", fontSize: 12 }} interval="preserveStartEnd" />
-            <YAxis domain={[1, 5]} tickLine={false} axisLine={false} tick={{ fill: "#64748b", fontSize: 12 }} allowDecimals />
+            <CartesianGrid strokeDasharray="4 8" stroke="currentColor" strokeOpacity={0.25} vertical={false} />
+            <XAxis
+              dataKey="label"
+              tickLine={false}
+              axisLine={false}
+              tick={{ fill: "currentColor", fontSize: 12 }}
+              interval="preserveStartEnd"
+            />
+            <YAxis
+              domain={[1, 5]}
+              tickLine={false}
+              axisLine={false}
+              tick={{ fill: "currentColor", fontSize: 12 }}
+              allowDecimals
+            />
             <Tooltip
               cursor={{ stroke: "rgba(14,165,233,0.2)", strokeWidth: 2 }}
               contentStyle={tooltipStyles}

--- a/syncback/components/dashboard/StatsGrid.module.css
+++ b/syncback/components/dashboard/StatsGrid.module.css
@@ -4,13 +4,17 @@
 
 .card {
   transition: transform 200ms ease, box-shadow 200ms ease;
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 255, 0.7));
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  background: light-dark(
+    linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 255, 0.7)),
+    linear-gradient(160deg, rgba(30, 41, 59, 0.92), rgba(15, 23, 42, 0.7))
+  );
+  box-shadow: light-dark(0 12px 30px rgba(15, 23, 42, 0.08), 0 14px 38px rgba(2, 6, 23, 0.45));
+  border: 1px solid light-dark(rgba(226, 232, 240, 0.7), rgba(71, 85, 105, 0.6));
 }
 
 .card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+  box-shadow: light-dark(0 18px 36px rgba(15, 23, 42, 0.12), 0 18px 42px rgba(8, 15, 35, 0.55));
 }
 
 .value {
@@ -27,7 +31,7 @@
 }
 
 .icon {
-  color: light-dark(var(--mantine-color-blue-4), var(--mantine-color-dark-3));
+  color: light-dark(var(--mantine-color-blue-4), rgba(125, 211, 252, 0.8));
 }
 
 .title {

--- a/syncback/components/home/sections/CallToActionSection.tsx
+++ b/syncback/components/home/sections/CallToActionSection.tsx
@@ -5,7 +5,7 @@ export function CallToActionSection() {
   return (
     <section
       id="get-started"
-      className="js-section-cta relative overflow-hidden rounded-[40px] border border-slate-200/80 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-10 text-white shadow-2xl shadow-slate-900/30"
+      className="js-section-cta relative overflow-hidden rounded-[40px] border border-slate-200/80 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-10 text-white shadow-2xl shadow-slate-900/30 dark:border-slate-700/80 dark:from-slate-900 dark:via-slate-900 dark:to-slate-900/90 dark:shadow-slate-900/60"
     >
       <div className="absolute inset-0 bg-noise opacity-30 mix-blend-overlay" aria-hidden />
       <div className="relative z-10 flex flex-col items-start gap-6 lg:flex-row lg:items-center lg:justify-between">
@@ -17,7 +17,7 @@ export function CallToActionSection() {
         </div>
         <Link
           href="#"
-          className="group inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-base font-semibold text-slate-900 shadow-xl transition hover:scale-[1.03]"
+          className="group inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-base font-semibold text-slate-900 shadow-xl transition hover:scale-[1.03] dark:bg-sky-500 dark:text-slate-900 dark:shadow-sky-500/40 dark:hover:bg-sky-400"
         >
           Create your free account
           <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" aria-hidden />

--- a/syncback/components/home/sections/HeroSection.tsx
+++ b/syncback/components/home/sections/HeroSection.tsx
@@ -13,9 +13,9 @@ export type HeroSectionProps = {
 
 export function HeroSection({ isPulsing }: HeroSectionProps) {
   return (
-    <section className="js-section-hero relative grid gap-16 lg:grid-cols-[minmax(0,_1fr)_minmax(0,_1fr)] lg:items-center">
+    <section className="js-section-hero relative grid gap-16 lg:grid-cols-[minmax(0,_1fr)_minmax(0,_1fr)] lg:items-center dark:text-slate-100">
       <div className="space-y-8">
-        <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm backdrop-blur">
+        <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-200">
           <Sparkles className="h-4 w-4 text-sky-500" aria-hidden />
           Feedback that flows back instantly
         </span>
@@ -26,42 +26,45 @@ export function HeroSection({ isPulsing }: HeroSectionProps) {
             }`}
             aria-hidden
           />
-          <h1 className="relative text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl lg:text-6xl">
+          <h1 className="relative text-4xl font-semibold tracking-tight text-slate-900 dark:text-slate-100 sm:text-5xl lg:text-6xl">
             Close the feedback loop the moment customers scan with SyncBack.
           </h1>
         </div>
-        <p className="max-w-xl text-lg text-slate-600 sm:text-xl">
+        <p className="max-w-xl text-lg text-slate-600 dark:text-slate-300 sm:text-xl">
           SyncBack is the QR-powered feedback lane that brings candid ratings straight to your inbox—no apps, no logins, just
           beautifully simple insights you can act on today.
         </p>
         <div className="flex flex-col gap-4 sm:flex-row">
           <Link
             href="#get-started"
-            className="group inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-base font-medium text-white shadow-lg shadow-slate-900/20 transition hover:scale-[1.02] hover:bg-slate-800"
+            className="group inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-base font-medium text-white shadow-lg shadow-slate-900/20 transition hover:scale-[1.02] hover:bg-slate-800 dark:bg-sky-500 dark:text-slate-900 dark:shadow-sky-500/30 dark:hover:bg-sky-400"
           >
             Start for free
             <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" aria-hidden />
           </Link>
           <Link
             href="#tour"
-            className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white/80 px-6 py-3 text-base font-medium text-slate-900 shadow-sm backdrop-blur transition hover:-translate-y-0.5 hover:border-slate-300"
+            className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white/80 px-6 py-3 text-base font-medium text-slate-900 shadow-sm backdrop-blur transition hover:-translate-y-0.5 hover:border-slate-300 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-100 dark:hover:border-slate-600"
           >
             See how it works
           </Link>
         </div>
-        <div className="grid max-w-2xl grid-cols-2 gap-4 text-sm text-slate-600 sm:grid-cols-3">
+        <div className="grid max-w-2xl grid-cols-2 gap-4 text-sm text-slate-600 dark:text-slate-300 sm:grid-cols-3">
           {floatingStats.map((stat) => (
-            <div key={stat.label} className="rounded-2xl border border-white/60 bg-white/70 p-4 text-center shadow-sm backdrop-blur">
-              <p className="text-2xl font-semibold text-slate-900">{stat.value}</p>
-              <p>{stat.label}</p>
+            <div
+              key={stat.label}
+              className="rounded-2xl border border-white/60 bg-white/70 p-4 text-center shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-800/60 dark:shadow-slate-900/30"
+            >
+              <p className="text-2xl font-semibold text-slate-900 dark:text-white">{stat.value}</p>
+              <p className="dark:text-slate-300">{stat.label}</p>
             </div>
           ))}
         </div>
       </div>
 
       <div className="relative flex flex-col items-center justify-center gap-6">
-        <div className="relative h-full w-full max-w-[420px] rounded-[36px] border border-white/80 bg-white/80 p-6 shadow-xl shadow-slate-900/10 backdrop-blur">
-          <div className="flex items-center justify-between rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6 text-white">
+        <div className="relative h-full w-full max-w-[420px] rounded-[36px] border border-white/80 bg-white/80 p-6 shadow-xl shadow-slate-900/10 backdrop-blur dark:border-slate-700 dark:bg-slate-900/60 dark:shadow-slate-900/40">
+          <div className="flex items-center justify-between rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6 text-white dark:from-slate-800 dark:via-slate-700 dark:to-slate-900">
             <div>
               <p className="text-sm text-white/70">New feedback</p>
               <p className="text-2xl font-semibold">“Service was so attentive today!”</p>
@@ -71,35 +74,35 @@ export function HeroSection({ isPulsing }: HeroSectionProps) {
                 ))}
               </div>
             </div>
-            <div className="rounded-full bg-white/10 p-3">
+            <div className="rounded-full bg-white/10 p-3 dark:bg-sky-500/20">
               <MessageCircle className="h-6 w-6" aria-hidden />
             </div>
           </div>
           <div className="mt-6 space-y-4">
-            <div className="group flex items-start gap-4 rounded-2xl border border-slate-200/80 bg-white/80 p-4 shadow-sm backdrop-blur transition hover:-translate-y-1 hover:border-slate-300">
-              <div className="rounded-full bg-slate-900/90 p-2 text-white shadow-lg">
+            <div className="group flex items-start gap-4 rounded-2xl border border-slate-200/80 bg-white/80 p-4 shadow-sm backdrop-blur transition hover:-translate-y-1 hover:border-slate-300 dark:border-slate-700/80 dark:bg-slate-800/70 dark:hover:border-slate-600">
+              <div className="rounded-full bg-slate-900/90 p-2 text-white shadow-lg dark:bg-sky-500/20 dark:text-sky-300">
                 <QrCode className="h-5 w-5" aria-hidden />
               </div>
               <div>
-                <p className="text-sm font-medium text-slate-900">Lobby kiosk</p>
-                <p className="text-sm text-slate-600">“Loved the express checkout. Keep it up!”</p>
+                <p className="text-sm font-medium text-slate-900 dark:text-slate-100">Lobby kiosk</p>
+                <p className="text-sm text-slate-600 dark:text-slate-300">“Loved the express checkout. Keep it up!”</p>
               </div>
             </div>
-            <div className="animate-float animate-glow rounded-2xl border border-slate-200/70 bg-white/80 p-5 shadow-lg backdrop-blur">
+            <div className="animate-float animate-glow rounded-2xl border border-slate-200/70 bg-white/80 p-5 shadow-lg backdrop-blur dark:border-slate-700/70 dark:bg-slate-800/70 dark:shadow-slate-900/40">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Email alert sent to</p>
-                  <p className="text-base font-semibold text-slate-900">hello@syncback.com</p>
+                  <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Email alert sent to</p>
+                  <p className="text-base font-semibold text-slate-900 dark:text-slate-100">hello@syncback.com</p>
                 </div>
                 <Mail className="h-5 w-5 text-sky-500" aria-hidden />
               </div>
-              <p className="mt-4 text-sm text-slate-600">
+              <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">
                 “Team handled our concern within minutes. Really appreciated the follow up!”
               </p>
             </div>
           </div>
         </div>
-        <div className="flex items-center gap-2 rounded-3xl border border-white/70 bg-white/80 px-5 py-4 text-sm font-medium text-slate-700 shadow-lg shadow-slate-900/10 backdrop-blur animate-float">
+        <div className="flex items-center gap-2 rounded-3xl border border-white/70 bg-white/80 px-5 py-4 text-sm font-medium text-slate-700 shadow-lg shadow-slate-900/10 backdrop-blur animate-float dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-200 dark:shadow-slate-900/40">
           <div className="flex items-center gap-1 text-amber-400">
             {[...Array(5)].map((_, index) => (
               <Star key={`floating-${index}`} className="h-4 w-4 fill-amber-400 text-amber-400" />

--- a/syncback/components/home/sections/HighlightsSection.tsx
+++ b/syncback/components/home/sections/HighlightsSection.tsx
@@ -26,19 +26,19 @@ export function HighlightsSection() {
   return (
     <section
       id="tour"
-      className="js-section-perks grid gap-10 rounded-[36px] border border-white/70 bg-white/70 p-10 shadow-xl shadow-slate-900/5 backdrop-blur lg:grid-cols-3"
+      className="js-section-perks grid gap-10 rounded-[36px] border border-white/70 bg-white/70 p-10 shadow-xl shadow-slate-900/5 backdrop-blur lg:grid-cols-3 dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40"
     >
       {highlights.map(({ icon: Icon, title, description }) => (
         <div
           key={title}
-          className="group flex flex-col gap-4 rounded-3xl border border-transparent bg-white/0 p-6 transition duration-500 hover:-translate-y-2 hover:border-slate-200 hover:bg-white/70"
+          className="group flex flex-col gap-4 rounded-3xl border border-transparent bg-white/0 p-6 transition duration-500 hover:-translate-y-2 hover:border-slate-200 hover:bg-white/70 dark:border-slate-700/60 dark:bg-slate-900/40 dark:hover:border-slate-600 dark:hover:bg-slate-900/70"
         >
-          <div className="w-fit rounded-full bg-slate-900/90 p-3 text-white shadow-lg shadow-slate-900/20 transition duration-500 group-hover:scale-110 group-hover:bg-slate-900">
+          <div className="w-fit rounded-full bg-slate-900/90 p-3 text-white shadow-lg shadow-slate-900/20 transition duration-500 group-hover:scale-110 group-hover:bg-slate-900 dark:bg-sky-500/20 dark:text-sky-300 dark:shadow-slate-900/40">
             <Icon className="h-5 w-5" aria-hidden />
           </div>
           <div className="space-y-2">
-            <h3 className="text-xl font-semibold text-slate-900">{title}</h3>
-            <p className="text-sm text-slate-600">{description}</p>
+            <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{title}</h3>
+            <p className="text-sm text-slate-600 dark:text-slate-300">{description}</p>
           </div>
         </div>
       ))}

--- a/syncback/components/home/sections/TestimonialsSection.tsx
+++ b/syncback/components/home/sections/TestimonialsSection.tsx
@@ -13,12 +13,12 @@ const testimonials = [
 
 export function TestimonialsSection() {
   return (
-    <section className="js-section-testimonials rounded-[32px] border border-white/70 bg-white/70 p-10 shadow-xl shadow-slate-900/5 backdrop-blur">
+    <section className="js-section-testimonials rounded-[32px] border border-white/70 bg-white/70 p-10 shadow-xl shadow-slate-900/5 backdrop-blur dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
       <div className="grid gap-10 lg:grid-cols-[0.8fr_1.2fr]">
         <div className="space-y-4">
-          <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Loved by teams</span>
-          <h2 className="text-3xl font-semibold text-slate-900 sm:text-4xl">Real teams, real-time improvements.</h2>
-          <p className="text-base text-slate-600">
+          <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Loved by teams</span>
+          <h2 className="text-3xl font-semibold text-slate-900 sm:text-4xl dark:text-slate-100">Real teams, real-time improvements.</h2>
+          <p className="text-base text-slate-600 dark:text-slate-300">
             SyncBack keeps the spotlight on customer joy. The more you listen, the faster you iterate.
           </p>
         </div>
@@ -26,12 +26,12 @@ export function TestimonialsSection() {
           {testimonials.map(({ quote, name, role }) => (
             <div
               key={name}
-              className="group flex h-full flex-col justify-between rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-lg shadow-slate-900/5 transition hover:-translate-y-2 hover:border-slate-300 hover:shadow-xl"
+              className="group flex h-full flex-col justify-between rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-lg shadow-slate-900/5 transition hover:-translate-y-2 hover:border-slate-300 hover:shadow-xl dark:border-slate-700/80 dark:bg-slate-800/60 dark:text-slate-100 dark:shadow-slate-900/30 dark:hover:border-slate-600"
             >
-              <p className="text-base text-slate-700">{quote}</p>
+              <p className="text-base text-slate-700 dark:text-slate-200">{quote}</p>
               <div className="mt-6">
-                <p className="text-sm font-semibold text-slate-900">{name}</p>
-                <p className="text-xs text-slate-500">{role}</p>
+                <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{name}</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">{role}</p>
               </div>
             </div>
           ))}

--- a/syncback/components/home/sections/WorkflowSection.tsx
+++ b/syncback/components/home/sections/WorkflowSection.tsx
@@ -19,29 +19,29 @@ const steps = [
 export function WorkflowSection() {
   return (
     <section className="js-section-workflow grid gap-12 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
-      <div className="rounded-[32px] border border-white/70 bg-white/80 p-8 shadow-lg shadow-slate-900/10 backdrop-blur">
-        <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Workflow</span>
-        <h2 className="mt-4 text-3xl font-semibold text-slate-900 sm:text-4xl">From scan to inbox in a heartbeat.</h2>
-        <p className="mt-4 text-base text-slate-600">
+      <div className="rounded-[32px] border border-white/70 bg-white/80 p-8 shadow-lg shadow-slate-900/10 backdrop-blur dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
+        <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Workflow</span>
+        <h2 className="mt-4 text-3xl font-semibold text-slate-900 sm:text-4xl dark:text-slate-100">From scan to inbox in a heartbeat.</h2>
+        <p className="mt-4 text-base text-slate-600 dark:text-slate-300">
           SyncBack was designed for busy teams that value clarity over clutter. Every step is purposefully light so you can move
           from setup to actionable feedback in minutes.
         </p>
         <div className="mt-8 space-y-6">
           {steps.map((step, index) => (
             <div key={step.title} className="relative pl-12">
-              <div className="absolute left-0 top-1 flex h-10 w-10 items-center justify-center rounded-full bg-slate-900 text-white shadow-md shadow-slate-900/20">
+              <div className="absolute left-0 top-1 flex h-10 w-10 items-center justify-center rounded-full bg-slate-900 text-white shadow-md shadow-slate-900/20 dark:bg-sky-500/20 dark:text-sky-300 dark:shadow-slate-900/40">
                 <span className="text-base font-semibold">{index + 1}</span>
               </div>
-              <h3 className="text-lg font-semibold text-slate-900">{step.title}</h3>
-              <p className="mt-2 text-sm text-slate-600">{step.description}</p>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{step.title}</h3>
+              <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{step.description}</p>
             </div>
           ))}
         </div>
       </div>
       <div className="relative flex items-center justify-center">
-        <div className="absolute inset-0 -z-10 rounded-[40px] bg-gradient-to-br from-sky-200/70 via-indigo-200/40 to-transparent blur-2xl" aria-hidden />
-        <div className="relative w-full max-w-xl rounded-[40px] border border-white/80 bg-white/80 p-6 shadow-2xl shadow-slate-900/10 backdrop-blur">
-          <div className="rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6 text-white">
+        <div className="absolute inset-0 -z-10 rounded-[40px] bg-gradient-to-br from-sky-200/70 via-indigo-200/40 to-transparent blur-2xl dark:from-sky-500/10 dark:via-sky-500/0" aria-hidden />
+        <div className="relative w-full max-w-xl rounded-[40px] border border-white/80 bg-white/80 p-6 shadow-2xl shadow-slate-900/10 backdrop-blur dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
+          <div className="rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6 text-white dark:from-slate-900 dark:via-slate-900 dark:to-slate-900/90">
             <p className="text-sm uppercase tracking-[0.3em] text-white/60">Live session</p>
             <p className="mt-4 text-2xl font-semibold">Guest Feedback Board</p>
             <div className="mt-6 space-y-4 text-sm text-white/80">
@@ -53,7 +53,7 @@ export function WorkflowSection() {
               <div className="rounded-2xl bg-white/10 p-4">“Tables were spotless and QR flow was effortless.”</div>
             </div>
           </div>
-          <div className="mt-6 rounded-2xl border border-slate-200/70 bg-white/80 p-5 text-sm text-slate-600 shadow-sm backdrop-blur">
+          <div className="mt-6 rounded-2xl border border-slate-200/70 bg-white/80 p-5 text-sm text-slate-600 shadow-sm backdrop-blur dark:border-slate-700/70 dark:bg-slate-800/70 dark:text-slate-300 dark:shadow-slate-900/30">
             Your team is automatically looped in with actionable emails—no dashboards required.
           </div>
         </div>

--- a/syncback/components/navigation/DarkModeToggle.tsx
+++ b/syncback/components/navigation/DarkModeToggle.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import clsx from "clsx";
+
+import { useTheme } from "@/lib/theme-context";
+
+export function DarkModeToggle() {
+  const { colorScheme, setColorScheme } = useTheme();
+  const isDark = colorScheme === "dark";
+
+  return (
+    <div className="flex items-center">
+      <button
+        type="button"
+        aria-label="Enable dark mode"
+        aria-pressed={isDark}
+        onClick={() => setColorScheme("dark")}
+        className={clsx(
+          "hs-dark-mode-active:hidden hs-dark-mode font-medium text-gray-800 rounded-full hover:bg-gray-200 focus:outline-hidden focus:bg-gray-200",
+          { block: !isDark, hidden: isDark },
+        )}
+      >
+        <span className="group inline-flex shrink-0 justify-center items-center size-9">
+          <svg
+            className="shrink-0 size-4"
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+          </svg>
+        </span>
+      </button>
+      <button
+        type="button"
+        aria-label="Enable light mode"
+        aria-pressed={!isDark}
+        onClick={() => setColorScheme("light")}
+        className={clsx(
+          "hs-dark-mode-active:block hs-dark-mode font-medium text-gray-800 rounded-full hover:bg-gray-200 focus:outline-hidden focus:bg-gray-200",
+          { block: isDark, hidden: !isDark },
+        )}
+      >
+        <span className="group inline-flex shrink-0 justify-center items-center size-9">
+          <svg
+            className="shrink-0 size-4"
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="4" />
+            <path d="M12 2v2" />
+            <path d="M12 20v2" />
+            <path d="m4.93 4.93 1.41 1.41" />
+            <path d="m17.66 17.66 1.41 1.41" />
+            <path d="M2 12h2" />
+            <path d="M20 12h2" />
+            <path d="m6.34 17.66-1.41 1.41" />
+            <path d="m19.07 4.93-1.41 1.41" />
+          </svg>
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/syncback/components/navigation/DarkModeToggle.tsx
+++ b/syncback/components/navigation/DarkModeToggle.tsx
@@ -15,7 +15,7 @@ export function DarkModeToggle() {
         aria-pressed={isDark}
         onClick={() => setColorScheme("dark")}
         className={clsx(
-          "hs-dark-mode-active:hidden hs-dark-mode font-medium text-gray-800 rounded-full hover:bg-gray-200 focus:outline-hidden focus:bg-gray-200",
+          "hs-dark-mode-active:hidden hs-dark-mode font-medium text-gray-800 rounded-full hover:bg-gray-200 focus:outline-hidden focus:bg-gray-200 dark:text-slate-200 dark:hover:bg-slate-800/60 dark:focus:bg-slate-800/60",
           { block: !isDark, hidden: isDark },
         )}
       >
@@ -42,7 +42,7 @@ export function DarkModeToggle() {
         aria-pressed={!isDark}
         onClick={() => setColorScheme("light")}
         className={clsx(
-          "hs-dark-mode-active:block hs-dark-mode font-medium text-gray-800 rounded-full hover:bg-gray-200 focus:outline-hidden focus:bg-gray-200",
+          "hs-dark-mode-active:block hs-dark-mode font-medium text-amber-500 rounded-full hover:bg-amber-500/10 focus:outline-hidden focus:bg-amber-500/10 dark:text-amber-300",
           { block: isDark, hidden: !isDark },
         )}
       >

--- a/syncback/components/navigation/DarkModeToggle.tsx
+++ b/syncback/components/navigation/DarkModeToggle.tsx
@@ -5,8 +5,7 @@ import clsx from "clsx";
 import { useTheme } from "@/lib/theme-context";
 
 export function DarkModeToggle() {
-  const { colorScheme, setColorScheme } = useTheme();
-  const isDark = colorScheme === "dark";
+  const { isDark, setColorScheme } = useTheme();
 
   return (
     <div className="flex items-center">

--- a/syncback/components/navigation/HeaderMegaMenu.module.css
+++ b/syncback/components/navigation/HeaderMegaMenu.module.css
@@ -46,3 +46,19 @@
   padding-bottom: var(--mantine-spacing-xl);
   border-top: 1px solid light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
 }
+
+:global(.dark) .header {
+  border-bottom-color: var(--mantine-color-dark-4);
+}
+
+:global(.dark) .link {
+  color: var(--mantine-color-white);
+}
+
+:global(.dark) .link:hover {
+  background-color: var(--mantine-color-dark-6);
+}
+
+:global(.dark) .subLink:hover {
+  background-color: var(--mantine-color-dark-7);
+}

--- a/syncback/components/navigation/HeaderMegaMenu.tsx
+++ b/syncback/components/navigation/HeaderMegaMenu.tsx
@@ -30,6 +30,7 @@ import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
 import Link from "next/link";
 import { useDisclosure } from "@mantine/hooks";
 import classes from "./HeaderMegaMenu.module.css";
+import { DarkModeToggle } from "./DarkModeToggle";
 
 type MockDataItem = {
   icon: (props: TablerIconsProps) => JSX.Element;
@@ -120,7 +121,8 @@ export function HeaderMegaMenu() {
             </SignedIn>
           </Group>
 
-          <Group visibleFrom="sm" gap="sm">
+          <Group visibleFrom="sm" gap="sm" align="center">
+            <DarkModeToggle />
             <SignedOut>
               <Button component={Link} href="/sign-in" variant="default">
                 Log in
@@ -178,6 +180,10 @@ export function HeaderMegaMenu() {
           </a>
 
           <Divider my="sm" />
+
+          <Group justify="flex-start" px="md" pb="md">
+            <DarkModeToggle />
+          </Group>
 
           <SignedOut>
             <Group justify="center" grow pb="xl" px="md">

--- a/syncback/components/navigation/HeaderMegaMenu.tsx
+++ b/syncback/components/navigation/HeaderMegaMenu.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import clsx from "clsx";
+
 import {
   IconBook,
   IconChartPie3,
@@ -31,6 +33,7 @@ import Link from "next/link";
 import { useDisclosure } from "@mantine/hooks";
 import classes from "./HeaderMegaMenu.module.css";
 import { DarkModeToggle } from "./DarkModeToggle";
+import { useTheme } from "@/lib/theme-context";
 
 type MockDataItem = {
   icon: (props: TablerIconsProps) => JSX.Element;
@@ -75,12 +78,18 @@ export function HeaderMegaMenu() {
   const [drawerOpened, { toggle: toggleDrawer, close: closeDrawer }] = useDisclosure(false);
   const [linksOpened, { toggle: toggleLinks }] = useDisclosure(false);
   const theme = useMantineTheme();
+  const { isDark, themeClassName } = useTheme();
+
+  const accentColor = isDark ? theme.white : theme.colors.blue[6];
+  const subtleAccentColor = isDark ? theme.colors.blue[2] : theme.colors.blue[6];
+  const brandIconVariant = isDark ? "filled" : "light";
+  const featureIconVariant = isDark ? "filled" : "default";
 
   const links = mockdata.map((item) => (
     <UnstyledButton className={classes.subLink} key={item.title}>
       <Group wrap="nowrap" align="flex-start">
-        <ThemeIcon size={34} variant="default" radius="md">
-          <item.icon size={22} color={theme.colors.blue[6]} />
+        <ThemeIcon size={34} variant={featureIconVariant} radius="md" color="blue">
+          <item.icon size={22} color={accentColor} />
         </ThemeIcon>
         <div>
           <Text size="sm" fw={500}>
@@ -95,12 +104,12 @@ export function HeaderMegaMenu() {
   ));
 
   return (
-    <Box pb={24}>
+    <Box pb={24} className={clsx(themeClassName)}>
       <header className={classes.header}>
         <Group justify="space-between" h="100%">
           <Group gap="xs">
-            <ThemeIcon size={36} radius="xl" variant="light" color="blue">
-              <IconRefresh size={22} />
+            <ThemeIcon size={36} radius="xl" variant={brandIconVariant} color="blue">
+              <IconRefresh size={22} color={accentColor} />
             </ThemeIcon>
             <Text fw={700} size="xl">
               syncback
@@ -168,7 +177,7 @@ export function HeaderMegaMenu() {
               <Box component="span" mr={5}>
                 Features
               </Box>
-              <IconChevronDown size={16} color={theme.colors.blue[6]} />
+              <IconChevronDown size={16} color={subtleAccentColor} />
             </Center>
           </UnstyledButton>
           <Collapse in={linksOpened}>{links}</Collapse>

--- a/syncback/lib/theme-context.tsx
+++ b/syncback/lib/theme-context.tsx
@@ -15,6 +15,10 @@ type ColorScheme = "light" | "dark";
 
 type ThemeContextValue = {
   colorScheme: ColorScheme;
+  /** Convenience boolean for checking if the current scheme is dark */
+  isDark: boolean;
+  /** Utility class name that can be spread onto components */
+  themeClassName: string | undefined;
   setColorScheme: (value: ColorScheme) => void;
   toggleColorScheme: () => void;
 };
@@ -68,14 +72,17 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     setColorSchemeState((current) => (current === "dark" ? "light" : "dark"));
   }, []);
 
-  const contextValue = useMemo(
-    () => ({
+  const contextValue = useMemo(() => {
+    const isDark = colorScheme === "dark";
+
+    return {
       colorScheme,
+      isDark,
+      themeClassName: isDark ? "dark" : undefined,
       setColorScheme,
       toggleColorScheme,
-    }),
-    [colorScheme, setColorScheme, toggleColorScheme],
-  );
+    } satisfies ThemeContextValue;
+  }, [colorScheme, setColorScheme, toggleColorScheme]);
 
   return (
     <ThemeContext.Provider value={contextValue}>

--- a/syncback/lib/theme-context.tsx
+++ b/syncback/lib/theme-context.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { MantineProvider } from "@mantine/core";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+type ColorScheme = "light" | "dark";
+
+type ThemeContextValue = {
+  colorScheme: ColorScheme;
+  setColorScheme: (value: ColorScheme) => void;
+  toggleColorScheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [colorScheme, setColorSchemeState] = useState<ColorScheme>("light");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const stored = window.localStorage.getItem("color-scheme");
+    if (stored === "dark" || stored === "light") {
+      setColorSchemeState(stored);
+      return;
+    }
+
+    if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      setColorSchemeState("dark");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!mounted || typeof document === "undefined") {
+      return;
+    }
+
+    const root = document.documentElement;
+    const body = document.body;
+
+    root.classList.toggle("dark", colorScheme === "dark");
+    root.setAttribute("data-mantine-color-scheme", colorScheme);
+
+    if (body) {
+      body.classList.toggle("dark", colorScheme === "dark");
+    }
+
+    window.localStorage.setItem("color-scheme", colorScheme);
+  }, [colorScheme, mounted]);
+
+  const setColorScheme = useCallback((value: ColorScheme) => {
+    setColorSchemeState(value);
+  }, []);
+
+  const toggleColorScheme = useCallback(() => {
+    setColorSchemeState((current) => (current === "dark" ? "light" : "dark"));
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      colorScheme,
+      setColorScheme,
+      toggleColorScheme,
+    }),
+    [colorScheme, setColorScheme, toggleColorScheme],
+  );
+
+  return (
+    <ThemeContext.Provider value={contextValue}>
+      <MantineProvider defaultColorScheme="light" forceColorScheme={colorScheme}>
+        {children}
+      </MantineProvider>
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add a shared theme provider that persists color scheme choice and toggles the `dark` class on the document
- wire the provider into the app layout and expose a reusable dark mode toggle in the navigation header and drawer

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dda115d268832b96bba3d3e6a6b473