### PR TITLE
Improve dark mode navigation styling

### DIFF
--- a/syncback/app/(dashboard)/dashboard/page.tsx
+++ b/syncback/app/(dashboard)/dashboard/page.tsx
@@ -40,7 +40,7 @@ export default async function DashboardPage() {
     : null;
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950">
+    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950 dark:bg-slate-950 dark:text-slate-100">
       <HeaderMegaMenu />
       <PageBackground>
         <div className="absolute left-1/2 top-[-8%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(59,130,246,0.22),_rgba(255,255,255,0))] blur-3xl" />

--- a/syncback/app/(dashboard)/settings/page.tsx
+++ b/syncback/app/(dashboard)/settings/page.tsx
@@ -41,7 +41,7 @@ export default async function SettingsPage() {
   };
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950">
+    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950 dark:bg-slate-950 dark:text-slate-100">
       <HeaderMegaMenu />
       <PageBackground>
         <div className="absolute left-1/2 top-[-8%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(59,130,246,0.22),_rgba(255,255,255,0))] blur-3xl" />

--- a/syncback/app/page.tsx
+++ b/syncback/app/page.tsx
@@ -84,7 +84,7 @@ export default function Home() {
   }, []);
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950">
+    <div className="relative min-h-screen overflow-hidden bg-[#f5f7ff] text-slate-950 dark:bg-slate-950 dark:text-slate-100">
       <HeaderMegaMenu />
       <PageBackground gridClassName="opacity-50" noiseClassName="opacity-40 mix-blend-soft-light">
         <div className="absolute left-1/2 top-[-10%] h-[520px] w-[520px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(59,130,246,0.28),_rgba(255,255,255,0))] blur-3xl" />

--- a/syncback/components/navigation/DarkModeToggle.tsx
+++ b/syncback/components/navigation/DarkModeToggle.tsx
@@ -5,8 +5,7 @@ import clsx from "clsx";
 import { useTheme } from "@/lib/theme-context";
 
 export function DarkModeToggle() {
-  const { colorScheme, setColorScheme } = useTheme();
-  const isDark = colorScheme === "dark";
+  const { isDark, setColorScheme } = useTheme();
 
   return (
     <div className="flex items-center">

--- a/syncback/components/navigation/HeaderMegaMenu.module.css
+++ b/syncback/components/navigation/HeaderMegaMenu.module.css
@@ -46,3 +46,19 @@
   padding-bottom: var(--mantine-spacing-xl);
   border-top: 1px solid light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
 }
+
+:global(.dark) .header {
+  border-bottom-color: var(--mantine-color-dark-4);
+}
+
+:global(.dark) .link {
+  color: var(--mantine-color-white);
+}
+
+:global(.dark) .link:hover {
+  background-color: var(--mantine-color-dark-6);
+}
+
+:global(.dark) .subLink:hover {
+  background-color: var(--mantine-color-dark-7);
+}

--- a/syncback/components/navigation/HeaderMegaMenu.tsx
+++ b/syncback/components/navigation/HeaderMegaMenu.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import clsx from "clsx";
+
 import {
   IconBook,
   IconChartPie3,
@@ -31,6 +33,7 @@ import Link from "next/link";
 import { useDisclosure } from "@mantine/hooks";
 import classes from "./HeaderMegaMenu.module.css";
 import { DarkModeToggle } from "./DarkModeToggle";
+import { useTheme } from "@/lib/theme-context";
 
 type MockDataItem = {
   icon: (props: TablerIconsProps) => JSX.Element;
@@ -75,12 +78,18 @@ export function HeaderMegaMenu() {
   const [drawerOpened, { toggle: toggleDrawer, close: closeDrawer }] = useDisclosure(false);
   const [linksOpened, { toggle: toggleLinks }] = useDisclosure(false);
   const theme = useMantineTheme();
+  const { isDark, themeClassName } = useTheme();
+
+  const accentColor = isDark ? theme.white : theme.colors.blue[6];
+  const subtleAccentColor = isDark ? theme.colors.blue[2] : theme.colors.blue[6];
+  const brandIconVariant = isDark ? "filled" : "light";
+  const featureIconVariant = isDark ? "filled" : "default";
 
   const links = mockdata.map((item) => (
     <UnstyledButton className={classes.subLink} key={item.title}>
       <Group wrap="nowrap" align="flex-start">
-        <ThemeIcon size={34} variant="default" radius="md">
-          <item.icon size={22} color={theme.colors.blue[6]} />
+        <ThemeIcon size={34} variant={featureIconVariant} radius="md" color="blue">
+          <item.icon size={22} color={accentColor} />
         </ThemeIcon>
         <div>
           <Text size="sm" fw={500}>
@@ -95,12 +104,12 @@ export function HeaderMegaMenu() {
   ));
 
   return (
-    <Box pb={24}>
+    <Box pb={24} className={clsx(themeClassName)}>
       <header className={classes.header}>
         <Group justify="space-between" h="100%">
           <Group gap="xs">
-            <ThemeIcon size={36} radius="xl" variant="light" color="blue">
-              <IconRefresh size={22} />
+            <ThemeIcon size={36} radius="xl" variant={brandIconVariant} color="blue">
+              <IconRefresh size={22} color={accentColor} />
             </ThemeIcon>
             <Text fw={700} size="xl">
               syncback
@@ -168,7 +177,7 @@ export function HeaderMegaMenu() {
               <Box component="span" mr={5}>
                 Features
               </Box>
-              <IconChevronDown size={16} color={theme.colors.blue[6]} />
+              <IconChevronDown size={16} color={subtleAccentColor} />
             </Center>
           </UnstyledButton>
           <Collapse in={linksOpened}>{links}</Collapse>

--- a/syncback/lib/theme-context.tsx
+++ b/syncback/lib/theme-context.tsx
@@ -15,6 +15,10 @@ type ColorScheme = "light" | "dark";
 
 type ThemeContextValue = {
   colorScheme: ColorScheme;
+  /** Convenience boolean for checking if the current scheme is dark */
+  isDark: boolean;
+  /** Utility class name that can be spread onto components */
+  themeClassName: string | undefined;
   setColorScheme: (value: ColorScheme) => void;
   toggleColorScheme: () => void;
 };
@@ -68,14 +72,17 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     setColorSchemeState((current) => (current === "dark" ? "light" : "dark"));
   }, []);
 
-  const contextValue = useMemo(
-    () => ({
+  const contextValue = useMemo(() => {
+    const isDark = colorScheme === "dark";
+
+    return {
       colorScheme,
+      isDark,
+      themeClassName: isDark ? "dark" : undefined,
       setColorScheme,
       toggleColorScheme,
-    }),
-    [colorScheme, setColorScheme, toggleColorScheme],
-  );
+    } satisfies ThemeContextValue;
+  }, [colorScheme, setColorScheme, toggleColorScheme]);
 
   return (
     <ThemeContext.Provider value={contextValue}>


### PR DESCRIPTION
## Summary
- expose dark-mode helpers from the theme context for easy component styling
- adjust the header menu styling and colors so navigation items remain visible in dark mode
- update primary page containers to honor the dark color scheme with matching backgrounds and text

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dda3197db0832b8f57187eea9923b4