### PR TITLE
Refresh dark mode styling

### DIFF
--- a/syncback/app/(dashboard)/dashboard/sections/PerformanceOverviewSection.tsx
+++ b/syncback/app/(dashboard)/dashboard/sections/PerformanceOverviewSection.tsx
@@ -10,13 +10,13 @@ export function PerformanceOverviewSection({ businessName, metrics }: Performanc
   return (
     <section className="space-y-6">
       <div className="space-y-2">
-        <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500">Performance overview</p>
-        <h1 className="text-3xl font-semibold leading-tight text-slate-950 sm:text-4xl lg:text-5xl">Insights for {businessName}</h1>
-        <p className="max-w-2xl text-base text-slate-600 sm:text-lg">
+        <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">Performance overview</p>
+        <h1 className="text-3xl font-semibold leading-tight text-slate-950 dark:text-slate-100 sm:text-4xl lg:text-5xl">Insights for {businessName}</h1>
+        <p className="max-w-2xl text-base text-slate-600 dark:text-slate-300 sm:text-lg">
           Track how guests feel about every experience and spot momentum in your ratings at a glance.
         </p>
       </div>
-      <div className="overflow-hidden rounded-[32px] border border-white/60 bg-white/70 shadow-xl backdrop-blur">
+      <div className="overflow-hidden rounded-[32px] border border-white/60 bg-white/70 shadow-xl backdrop-blur dark:border-slate-700 dark:bg-slate-900/60 dark:shadow-slate-900/40">
         <StatsGrid metrics={metrics} />
       </div>
     </section>

--- a/syncback/app/(dashboard)/settings/sections/SettingsIntroSection.tsx
+++ b/syncback/app/(dashboard)/settings/sections/SettingsIntroSection.tsx
@@ -22,15 +22,15 @@ export function SettingsIntroSection() {
   return (
     <section className="grid gap-10 lg:grid-cols-[minmax(0,_1.05fr)_minmax(0,_0.95fr)] lg:items-center">
       <div className="space-y-7">
-        <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm backdrop-blur">
+        <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-200">
           <Sparkles className="h-4 w-4 text-sky-500" aria-hidden />
           Craft your feedback hub
         </span>
         <div className="space-y-4">
-          <h1 className="text-3xl font-semibold leading-tight text-slate-950 sm:text-4xl lg:text-5xl">
+          <h1 className="text-3xl font-semibold leading-tight text-slate-950 dark:text-slate-100 sm:text-4xl lg:text-5xl">
             Set up a beautiful QR-powered page for collecting guest feedback
           </h1>
-          <p className="max-w-xl text-base text-slate-600 sm:text-lg">
+          <p className="max-w-xl text-base text-slate-600 dark:text-slate-300 sm:text-lg">
             Add your business details once and we&rsquo;ll generate a shareable QR card plus a magic link that guides every guest back to your private feedback form.
           </p>
         </div>
@@ -39,30 +39,30 @@ export function SettingsIntroSection() {
           {highlights.map(({ icon: Icon, title, description }) => (
             <li
               key={title}
-              className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-lg"
+              className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-lg dark:border-slate-700 dark:bg-slate-800/70 dark:hover:shadow-slate-900/50"
             >
               <div className="flex items-center gap-3">
                 <div className="flex h-10 w-10 items-center justify-center rounded-full bg-sky-500/10 text-sky-600">
                   <Icon className="h-5 w-5" aria-hidden />
                 </div>
-                <h3 className="text-base font-semibold text-slate-900">{title}</h3>
+                <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">{title}</h3>
               </div>
-              <p className="mt-3 text-sm text-slate-600">{description}</p>
+              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{description}</p>
             </li>
           ))}
         </ul>
       </div>
 
       <div className="relative order-first flex items-center justify-center lg:order-last">
-        <div className="relative w-full max-w-md rounded-[32px] border border-white/70 bg-white/70 p-8 shadow-xl backdrop-blur">
+        <div className="relative w-full max-w-md rounded-[32px] border border-white/70 bg-white/70 p-8 shadow-xl backdrop-blur dark:border-slate-700 dark:bg-slate-900/60 dark:shadow-slate-900/40">
           <div className="absolute -left-6 top-8 hidden h-20 w-20 rounded-full bg-gradient-to-br from-sky-400/40 to-blue-500/10 blur-xl lg:block" />
           <div className="absolute -right-6 bottom-8 hidden h-24 w-24 rounded-full bg-gradient-to-br from-emerald-400/40 to-emerald-500/10 blur-xl lg:block" />
           <div className="relative flex flex-col items-center gap-5 text-center">
             <div className="rounded-full bg-sky-500/10 p-3 text-sky-600">
               <QrCode className="h-6 w-6" aria-hidden />
             </div>
-            <h2 className="text-xl font-semibold text-slate-900">Drop your details, receive a branded QR card</h2>
-            <p className="text-sm text-slate-600">
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Drop your details, receive a branded QR card</h2>
+            <p className="text-sm text-slate-600 dark:text-slate-300">
               Perfect for tabletops, checkout counters, event lanyards—wherever your guests linger.
             </p>
           </div>

--- a/syncback/components/home/sections/HeroSection.tsx
+++ b/syncback/components/home/sections/HeroSection.tsx
@@ -13,9 +13,9 @@ export type HeroSectionProps = {
 
 export function HeroSection({ isPulsing }: HeroSectionProps) {
   return (
-    <section className="js-section-hero relative grid gap-16 lg:grid-cols-[minmax(0,_1fr)_minmax(0,_1fr)] lg:items-center">
+    <section className="js-section-hero relative grid gap-16 lg:grid-cols-[minmax(0,_1fr)_minmax(0,_1fr)] lg:items-center dark:text-slate-100">
       <div className="space-y-8">
-        <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm backdrop-blur">
+        <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-200">
           <Sparkles className="h-4 w-4 text-sky-500" aria-hidden />
           Feedback that flows back instantly
         </span>
@@ -26,42 +26,45 @@ export function HeroSection({ isPulsing }: HeroSectionProps) {
             }`}
             aria-hidden
           />
-          <h1 className="relative text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl lg:text-6xl">
+          <h1 className="relative text-4xl font-semibold tracking-tight text-slate-900 dark:text-slate-100 sm:text-5xl lg:text-6xl">
             Close the feedback loop the moment customers scan with SyncBack.
           </h1>
         </div>
-        <p className="max-w-xl text-lg text-slate-600 sm:text-xl">
+        <p className="max-w-xl text-lg text-slate-600 dark:text-slate-300 sm:text-xl">
           SyncBack is the QR-powered feedback lane that brings candid ratings straight to your inbox—no apps, no logins, just
           beautifully simple insights you can act on today.
         </p>
         <div className="flex flex-col gap-4 sm:flex-row">
           <Link
             href="#get-started"
-            className="group inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-base font-medium text-white shadow-lg shadow-slate-900/20 transition hover:scale-[1.02] hover:bg-slate-800"
+            className="group inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-base font-medium text-white shadow-lg shadow-slate-900/20 transition hover:scale-[1.02] hover:bg-slate-800 dark:bg-sky-500 dark:text-slate-900 dark:shadow-sky-500/30 dark:hover:bg-sky-400"
           >
             Start for free
             <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" aria-hidden />
           </Link>
           <Link
             href="#tour"
-            className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white/80 px-6 py-3 text-base font-medium text-slate-900 shadow-sm backdrop-blur transition hover:-translate-y-0.5 hover:border-slate-300"
+            className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white/80 px-6 py-3 text-base font-medium text-slate-900 shadow-sm backdrop-blur transition hover:-translate-y-0.5 hover:border-slate-300 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-100 dark:hover:border-slate-600"
           >
             See how it works
           </Link>
         </div>
-        <div className="grid max-w-2xl grid-cols-2 gap-4 text-sm text-slate-600 sm:grid-cols-3">
+        <div className="grid max-w-2xl grid-cols-2 gap-4 text-sm text-slate-600 dark:text-slate-300 sm:grid-cols-3">
           {floatingStats.map((stat) => (
-            <div key={stat.label} className="rounded-2xl border border-white/60 bg-white/70 p-4 text-center shadow-sm backdrop-blur">
-              <p className="text-2xl font-semibold text-slate-900">{stat.value}</p>
-              <p>{stat.label}</p>
+            <div
+              key={stat.label}
+              className="rounded-2xl border border-white/60 bg-white/70 p-4 text-center shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-800/60 dark:shadow-slate-900/30"
+            >
+              <p className="text-2xl font-semibold text-slate-900 dark:text-white">{stat.value}</p>
+              <p className="dark:text-slate-300">{stat.label}</p>
             </div>
           ))}
         </div>
       </div>
 
       <div className="relative flex flex-col items-center justify-center gap-6">
-        <div className="relative h-full w-full max-w-[420px] rounded-[36px] border border-white/80 bg-white/80 p-6 shadow-xl shadow-slate-900/10 backdrop-blur">
-          <div className="flex items-center justify-between rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6 text-white">
+        <div className="relative h-full w-full max-w-[420px] rounded-[36px] border border-white/80 bg-white/80 p-6 shadow-xl shadow-slate-900/10 backdrop-blur dark:border-slate-700 dark:bg-slate-900/60 dark:shadow-slate-900/40">
+          <div className="flex items-center justify-between rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6 text-white dark:from-slate-800 dark:via-slate-700 dark:to-slate-900">
             <div>
               <p className="text-sm text-white/70">New feedback</p>
               <p className="text-2xl font-semibold">“Service was so attentive today!”</p>
@@ -71,35 +74,35 @@ export function HeroSection({ isPulsing }: HeroSectionProps) {
                 ))}
               </div>
             </div>
-            <div className="rounded-full bg-white/10 p-3">
+            <div className="rounded-full bg-white/10 p-3 dark:bg-sky-500/20">
               <MessageCircle className="h-6 w-6" aria-hidden />
             </div>
           </div>
           <div className="mt-6 space-y-4">
-            <div className="group flex items-start gap-4 rounded-2xl border border-slate-200/80 bg-white/80 p-4 shadow-sm backdrop-blur transition hover:-translate-y-1 hover:border-slate-300">
-              <div className="rounded-full bg-slate-900/90 p-2 text-white shadow-lg">
+            <div className="group flex items-start gap-4 rounded-2xl border border-slate-200/80 bg-white/80 p-4 shadow-sm backdrop-blur transition hover:-translate-y-1 hover:border-slate-300 dark:border-slate-700/80 dark:bg-slate-800/70 dark:hover:border-slate-600">
+              <div className="rounded-full bg-slate-900/90 p-2 text-white shadow-lg dark:bg-sky-500/20 dark:text-sky-300">
                 <QrCode className="h-5 w-5" aria-hidden />
               </div>
               <div>
-                <p className="text-sm font-medium text-slate-900">Lobby kiosk</p>
-                <p className="text-sm text-slate-600">“Loved the express checkout. Keep it up!”</p>
+                <p className="text-sm font-medium text-slate-900 dark:text-slate-100">Lobby kiosk</p>
+                <p className="text-sm text-slate-600 dark:text-slate-300">“Loved the express checkout. Keep it up!”</p>
               </div>
             </div>
-            <div className="animate-float animate-glow rounded-2xl border border-slate-200/70 bg-white/80 p-5 shadow-lg backdrop-blur">
+            <div className="animate-float animate-glow rounded-2xl border border-slate-200/70 bg-white/80 p-5 shadow-lg backdrop-blur dark:border-slate-700/70 dark:bg-slate-800/70 dark:shadow-slate-900/40">
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-xs uppercase tracking-wide text-slate-500">Email alert sent to</p>
-                  <p className="text-base font-semibold text-slate-900">hello@syncback.com</p>
+                  <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Email alert sent to</p>
+                  <p className="text-base font-semibold text-slate-900 dark:text-slate-100">hello@syncback.com</p>
                 </div>
                 <Mail className="h-5 w-5 text-sky-500" aria-hidden />
               </div>
-              <p className="mt-4 text-sm text-slate-600">
+              <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">
                 “Team handled our concern within minutes. Really appreciated the follow up!”
               </p>
             </div>
           </div>
         </div>
-        <div className="flex items-center gap-2 rounded-3xl border border-white/70 bg-white/80 px-5 py-4 text-sm font-medium text-slate-700 shadow-lg shadow-slate-900/10 backdrop-blur animate-float">
+        <div className="flex items-center gap-2 rounded-3xl border border-white/70 bg-white/80 px-5 py-4 text-sm font-medium text-slate-700 shadow-lg shadow-slate-900/10 backdrop-blur animate-float dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-200 dark:shadow-slate-900/40">
           <div className="flex items-center gap-1 text-amber-400">
             {[...Array(5)].map((_, index) => (
               <Star key={`floating-${index}`} className="h-4 w-4 fill-amber-400 text-amber-400" />

--- a/syncback/components/navigation/DarkModeToggle.tsx
+++ b/syncback/components/navigation/DarkModeToggle.tsx
@@ -15,7 +15,7 @@ export function DarkModeToggle() {
         aria-pressed={isDark}
         onClick={() => setColorScheme("dark")}
         className={clsx(
-          "hs-dark-mode-active:hidden hs-dark-mode font-medium text-gray-800 rounded-full hover:bg-gray-200 focus:outline-hidden focus:bg-gray-200",
+          "hs-dark-mode-active:hidden hs-dark-mode font-medium text-gray-800 rounded-full hover:bg-gray-200 focus:outline-hidden focus:bg-gray-200 dark:text-slate-200 dark:hover:bg-slate-800/60 dark:focus:bg-slate-800/60",
           { block: !isDark, hidden: isDark },
         )}
       >
@@ -42,7 +42,7 @@ export function DarkModeToggle() {
         aria-pressed={!isDark}
         onClick={() => setColorScheme("light")}
         className={clsx(
-          "hs-dark-mode-active:block hs-dark-mode font-medium text-gray-800 rounded-full hover:bg-gray-200 focus:outline-hidden focus:bg-gray-200",
+          "hs-dark-mode-active:block hs-dark-mode font-medium text-amber-500 rounded-full hover:bg-amber-500/10 focus:outline-hidden focus:bg-amber-500/10 dark:text-amber-300",
           { block: isDark, hidden: !isDark },
         )}
       >


### PR DESCRIPTION
## Summary
- refresh the hero section with darker backgrounds, lighter text, and more vibrant CTAs in dark mode
- align dashboard overview and settings intro sections with the updated dark-mode palette for readability
- tint the light-mode toggle sun icon to yellow for better affordance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dda6cceaf0832b8bce7d78f07337dd