### PR TITLE
Align dark mode cards with hero feedback styling

### DIFF
--- a/syncback/app/(dashboard)/dashboard/sections/PerformanceOverviewSection.tsx
+++ b/syncback/app/(dashboard)/dashboard/sections/PerformanceOverviewSection.tsx
@@ -16,7 +16,7 @@ export function PerformanceOverviewSection({ businessName, metrics }: Performanc
           Track how guests feel about every experience and spot momentum in your ratings at a glance.
         </p>
       </div>
-      <div className="overflow-hidden rounded-[32px] border border-white/60 bg-white/70 shadow-xl backdrop-blur dark:border-slate-700 dark:bg-slate-900/60 dark:shadow-slate-900/40">
+      <div className="overflow-hidden rounded-[32px] border border-white/60 bg-white/70 shadow-xl backdrop-blur dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
         <StatsGrid metrics={metrics} />
       </div>
     </section>

--- a/syncback/app/(dashboard)/dashboard/sections/RatingDistributionSection.tsx
+++ b/syncback/app/(dashboard)/dashboard/sections/RatingDistributionSection.tsx
@@ -7,13 +7,13 @@ export type RatingDistributionSectionProps = {
 
 export function RatingDistributionSection({ data }: RatingDistributionSectionProps) {
   return (
-    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl">
+    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-xl font-semibold text-slate-900">Rating distribution</h2>
-          <p className="text-sm text-slate-500">Share of responses by star level</p>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Rating distribution</h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400">Share of responses by star level</p>
         </div>
-        <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-600">Updated hourly</span>
+        <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-300">Updated hourly</span>
       </div>
       <div className="mt-8 h-72 w-full">
         <RatingDistributionChart data={data} />

--- a/syncback/app/(dashboard)/dashboard/sections/RatingTrendSection.tsx
+++ b/syncback/app/(dashboard)/dashboard/sections/RatingTrendSection.tsx
@@ -7,13 +7,13 @@ export type RatingTrendSectionProps = {
 
 export function RatingTrendSection({ data }: RatingTrendSectionProps) {
   return (
-    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl">
+    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-xl font-semibold text-slate-900">Rating trend</h2>
-          <p className="text-sm text-slate-500">Trailing six months of average guest ratings</p>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Rating trend</h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400">Trailing six months of average guest ratings</p>
         </div>
-        <span className="rounded-full bg-sky-500/10 px-3 py-1 text-xs font-medium text-sky-600">Live sync</span>
+        <span className="rounded-full bg-sky-500/10 px-3 py-1 text-xs font-medium text-sky-600 dark:bg-sky-500/20 dark:text-sky-300">Live sync</span>
       </div>
       <div className="mt-8 h-72 w-full">
         <RatingTrendChart data={data} />

--- a/syncback/app/(dashboard)/dashboard/sections/RecentFeedbackSection.tsx
+++ b/syncback/app/(dashboard)/dashboard/sections/RecentFeedbackSection.tsx
@@ -8,13 +8,13 @@ export type RecentFeedbackSectionProps = {
 
 export function RecentFeedbackSection({ feedback, totalCount }: RecentFeedbackSectionProps) {
   return (
-    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl lg:col-span-2">
+    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl lg:col-span-2 dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h2 className="text-xl font-semibold text-slate-900">Feedback details</h2>
-          <p className="text-sm text-slate-500">Review individual comments, search by rating, and spot outliers fast</p>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Feedback details</h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400">Review individual comments, search by rating, and spot outliers fast</p>
         </div>
-        <span className="inline-flex items-center rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-600">
+        <span className="inline-flex items-center rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-sky-500/10 dark:text-sky-300">
           {totalCount} feedback entries
         </span>
       </div>

--- a/syncback/app/(dashboard)/dashboard/sections/RecentRatingsSection.tsx
+++ b/syncback/app/(dashboard)/dashboard/sections/RecentRatingsSection.tsx
@@ -8,13 +8,13 @@ export type RecentRatingsSectionProps = {
 
 export function RecentRatingsSection({ ratings, totalCount }: RecentRatingsSectionProps) {
   return (
-    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl lg:col-span-2">
+    <section className="group relative overflow-hidden rounded-[32px] border border-white/60 bg-white/80 p-8 shadow-xl backdrop-blur transition-transform duration-200 hover:-translate-y-1 hover:shadow-2xl lg:col-span-2 dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h2 className="text-xl font-semibold text-slate-900">Recent ratings</h2>
-          <p className="text-sm text-slate-500">Explore the most recent feedback and spot shifts instantly</p>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Recent ratings</h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400">Explore the most recent feedback and spot shifts instantly</p>
         </div>
-        <span className="inline-flex items-center rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-600">
+        <span className="inline-flex items-center rounded-full bg-slate-900/5 px-3 py-1 text-xs font-medium text-slate-600 dark:bg-sky-500/10 dark:text-sky-300">
           {totalCount} total ratings
         </span>
       </div>

--- a/syncback/components/dashboard/RatingDistributionChart.tsx
+++ b/syncback/components/dashboard/RatingDistributionChart.tsx
@@ -38,7 +38,7 @@ export function RatingDistributionChart({ data }: RatingDistributionChartProps) 
   const domainMax = Math.max(10, Math.ceil((maxValue + 5) / 10) * 10);
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
+    <ResponsiveContainer width="100%" height="100%" className="text-slate-500 dark:text-slate-300">
       <RadarChart data={data} outerRadius="70%">
         <defs>
           <linearGradient id="radarGradient" x1="0" y1="0" x2="1" y2="1">
@@ -46,13 +46,13 @@ export function RatingDistributionChart({ data }: RatingDistributionChartProps) 
             <stop offset="100%" stopColor="#22d3ee" stopOpacity={0.4} />
           </linearGradient>
         </defs>
-        <PolarGrid stroke="rgba(148, 163, 184, 0.35)" radialLines={false} />
-        <PolarAngleAxis dataKey="segment" tick={{ fill: "#64748b", fontSize: 12 }} />
+        <PolarGrid stroke="currentColor" strokeOpacity={0.25} radialLines={false} />
+        <PolarAngleAxis dataKey="segment" tick={{ fill: "currentColor", fontSize: 12 }} />
         <PolarRadiusAxis
           angle={45}
           domain={[0, domainMax]}
           tickCount={5}
-          tick={{ fill: "#94a3b8", fontSize: 11 }}
+          tick={{ fill: "currentColor", fontSize: 11 }}
         />
         <Radar
           name="Ratings"

--- a/syncback/components/dashboard/RatingTrendChart.tsx
+++ b/syncback/components/dashboard/RatingTrendChart.tsx
@@ -51,7 +51,7 @@ export function RatingTrendChart({ data }: RatingTrendChartProps) {
   }
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
+    <ResponsiveContainer width="100%" height="100%" className="text-slate-500 dark:text-slate-300">
       <LineChart data={data} margin={{ top: 10, right: 20, left: -10, bottom: 0 }}>
         <defs>
           <linearGradient id="lineGradient" x1="0" y1="0" x2="0" y2="1">
@@ -59,13 +59,13 @@ export function RatingTrendChart({ data }: RatingTrendChartProps) {
             <stop offset="95%" stopColor="#0ea5e9" stopOpacity={0.1} />
           </linearGradient>
         </defs>
-        <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.35)" vertical={false} />
-        <XAxis dataKey="month" tickLine={false} axisLine={false} tick={{ fill: "#64748b", fontSize: 12 }} />
+        <CartesianGrid strokeDasharray="4 8" stroke="currentColor" strokeOpacity={0.25} vertical={false} />
+        <XAxis dataKey="month" tickLine={false} axisLine={false} tick={{ fill: "currentColor", fontSize: 12 }} />
         <YAxis
           domain={[lowerBound, upperBound]}
           tickLine={false}
           axisLine={false}
-          tick={{ fill: "#64748b", fontSize: 12 }}
+          tick={{ fill: "currentColor", fontSize: 12 }}
           allowDecimals
         />
         <Tooltip

--- a/syncback/components/dashboard/RecentFeedbackTable.tsx
+++ b/syncback/components/dashboard/RecentFeedbackTable.tsx
@@ -94,7 +94,7 @@ const columns: ColumnDef<FeedbackEntry>[] = [
     cell: ({ row }) => {
       const timestamp = row.getValue<string>("receivedAt");
       return (
-        <span className="text-sm text-slate-600">
+        <span className="text-sm text-slate-600 dark:text-slate-300">
           {dateFormatter.format(new Date(timestamp))}
         </span>
       );
@@ -127,7 +127,7 @@ const columns: ColumnDef<FeedbackEntry>[] = [
     header: "Feedback",
     accessorKey: "feedback",
     cell: ({ row }) => (
-      <p className="text-sm text-slate-700">{row.getValue("feedback")}</p>
+      <p className="text-sm text-slate-700 dark:text-slate-200">{row.getValue("feedback")}</p>
     ),
     meta: {
       filterVariant: "text",
@@ -376,7 +376,7 @@ function Filter({ column }: { column: Column<FeedbackEntry, unknown> }) {
             column.setFilterValue(value === "all" ? undefined : value);
           }}
         >
-          <SelectTrigger id={`${id}-select`}>
+          <SelectTrigger id={`${id}-select`} className="dark:border-slate-700/80 dark:bg-slate-900/60 dark:text-slate-200">
             <SelectValue placeholder="All ratings" />
           </SelectTrigger>
           <SelectContent>
@@ -407,15 +407,15 @@ function Filter({ column }: { column: Column<FeedbackEntry, unknown> }) {
               id={`${id}-date-trigger`}
               onClick={() => setIsCalendarOpen((open) => !open)}
               className={cn(
-                "inline-flex w-full items-center justify-between gap-2 rounded-xl border border-slate-200/80 bg-white px-3 py-2 text-left text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-300 hover:text-slate-900",
+                "inline-flex w-full items-center justify-between gap-2 rounded-xl border border-slate-200/80 bg-white px-3 py-2 text-left text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-300 hover:text-slate-900 dark:border-slate-700/80 dark:bg-slate-900/60 dark:text-slate-300 dark:hover:border-slate-600 dark:hover:text-slate-100",
                 hasSelection && "text-slate-900",
               )}
             >
               <span className="inline-flex items-center gap-2">
-                <CalendarIcon className="size-4 text-slate-400" aria-hidden="true" />
+                <CalendarIcon className="size-4 text-slate-400 dark:text-slate-500" aria-hidden="true" />
                 {label}
               </span>
-              <ChevronDownIcon className="size-4 text-slate-400" aria-hidden="true" />
+              <ChevronDownIcon className="size-4 text-slate-400 dark:text-slate-500" aria-hidden="true" />
             </button>
             {hasSelection ? (
               <button
@@ -424,7 +424,7 @@ function Filter({ column }: { column: Column<FeedbackEntry, unknown> }) {
                   column.setFilterValue(undefined);
                   setIsCalendarOpen(false);
                 }}
-                className="inline-flex items-center rounded-xl border border-transparent bg-slate-100 px-3 py-2 text-xs font-semibold text-slate-500 transition hover:bg-slate-200 hover:text-slate-700"
+                className="inline-flex items-center rounded-xl border border-transparent bg-slate-100 px-3 py-2 text-xs font-semibold text-slate-500 transition hover:bg-slate-200 hover:text-slate-700 dark:bg-slate-800/70 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-100"
               >
                 Clear
               </button>
@@ -432,7 +432,7 @@ function Filter({ column }: { column: Column<FeedbackEntry, unknown> }) {
           </div>
           {isCalendarOpen ? (
             <div className="absolute left-0 top-full z-50 mt-2 min-w-[18rem]">
-              <div className="origin-top overflow-hidden rounded-[28px] border border-slate-200/70 bg-white/95 p-3 shadow-xl">
+              <div className="origin-top overflow-hidden rounded-[28px] border border-slate-200/70 bg-white/95 p-3 shadow-xl dark:border-slate-700/70 dark:bg-slate-900/90 dark:shadow-slate-900/40">
                 <RangeCalendar
                   value={dateRangeValue}
                   onChange={(value) => {
@@ -456,7 +456,7 @@ function Filter({ column }: { column: Column<FeedbackEntry, unknown> }) {
       <div className="relative">
         <Input
           id={`${id}-input`}
-          className="peer ps-9"
+          className="peer ps-9 dark:border-slate-700/80 dark:bg-slate-900/60 dark:text-slate-200"
           value={(columnFilterValue ?? "") as string}
           onChange={(event) => column.setFilterValue(event.target.value)}
           placeholder={
@@ -465,7 +465,7 @@ function Filter({ column }: { column: Column<FeedbackEntry, unknown> }) {
           }
           type="text"
         />
-        <div className="pointer-events-none absolute inset-y-0 start-0 flex items-center justify-center ps-3 text-muted-foreground/80">
+        <div className="pointer-events-none absolute inset-y-0 start-0 flex items-center justify-center ps-3 text-muted-foreground/80 dark:text-slate-500">
           <SearchIcon size={16} />
         </div>
       </div>
@@ -526,16 +526,16 @@ function FeedbackDetailModal({
       <div className="flex flex-col gap-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400 dark:text-slate-500">
               Received on
             </p>
-            <p className="text-xl font-semibold text-slate-900">
+            <p className="text-xl font-semibold text-slate-900 dark:text-slate-100">
               {formattedDate}
             </p>
           </div>
           <div className="flex flex-col items-start gap-3 sm:items-end">
             <div className="space-y-1 text-left sm:text-right">
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400 dark:text-slate-500">
                 Rating
               </p>
               <div className="inline-flex items-center gap-3 rounded-full border border-amber-200/70 bg-amber-50/80 px-4 py-2 shadow-inner">
@@ -549,15 +549,15 @@ function FeedbackDetailModal({
                 />
               </div>
             </div>
-            <div className="flex items-center gap-2 text-sm text-slate-500">
+            <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
               <StarRating rating={entry.rating} />
               <span>{entry.rating.toFixed(1)} of 5 stars</span>
             </div>
           </div>
         </div>
 
-        <div className="rounded-3xl border border-slate-200/70 bg-white/90 p-6 shadow-inner">
-          <p className="text-base leading-relaxed text-slate-700">{entry.feedback}</p>
+        <div className="rounded-3xl border border-slate-200/70 bg-white/90 p-6 shadow-inner dark:border-slate-700/70 dark:bg-slate-900/70 dark:shadow-slate-900/40">
+          <p className="text-base leading-relaxed text-slate-700 dark:text-slate-200">{entry.feedback}</p>
         </div>
       </div>
     </BasicModal>

--- a/syncback/components/dashboard/RecentRatingsAreaChart.tsx
+++ b/syncback/components/dashboard/RecentRatingsAreaChart.tsx
@@ -106,7 +106,7 @@ export function RecentRatingsAreaChart({
 
   if (!hasRatings) {
     return (
-      <div className="flex h-full min-h-[18rem] flex-col items-center justify-center rounded-[32px] border border-dashed border-slate-200 bg-white/70 p-8 text-center text-sm text-slate-500">
+      <div className="flex h-full min-h-[18rem] flex-col items-center justify-center rounded-[32px] border border-dashed border-slate-200 bg-white/70 p-8 text-center text-sm text-slate-500 dark:border-slate-700/80 dark:bg-slate-900/60 dark:text-slate-300">
         <p>No ratings have been collected yet. Share your feedback link to start seeing momentum here.</p>
       </div>
     );
@@ -115,9 +115,9 @@ export function RecentRatingsAreaChart({
   return (
     <div className="flex h-full flex-col gap-8">
       <div className="flex flex-col gap-2">
-        <Label htmlFor="ratings-window" className="flex items-center justify-between text-slate-700">
+        <Label htmlFor="ratings-window" className="flex items-center justify-between text-slate-700 dark:text-slate-200">
           <span>Last {windowSize} ratings</span>
-          <span className="text-xs font-medium text-slate-400">Average {averageRating.toFixed(2)} ★</span>
+          <span className="text-xs font-medium text-slate-400 dark:text-slate-500">Average {averageRating.toFixed(2)} ★</span>
         </Label>
         <div>
           <Slider
@@ -131,7 +131,7 @@ export function RecentRatingsAreaChart({
             aria-label="Select the number of recent ratings to display"
           />
           <span
-            className="mt-3 flex w-full items-center justify-between gap-1 px-2.5 text-xs font-medium text-slate-400"
+            className="mt-3 flex w-full items-center justify-between gap-1 px-2.5 text-xs font-medium text-slate-400 dark:text-slate-500"
             aria-hidden="true"
           >
             {ticks.map((tick, index) => {
@@ -141,7 +141,7 @@ export function RecentRatingsAreaChart({
                 <span key={tick} className="flex w-0 flex-col items-center justify-center gap-2">
                   <span
                     className={cn(
-                      "bg-slate-400/70 h-1 w-px",
+                      "h-1 w-px bg-slate-400/70 dark:bg-slate-600/60",
                       !showLabel && "h-0.5",
                     )}
                   />
@@ -153,7 +153,7 @@ export function RecentRatingsAreaChart({
         </div>
       </div>
 
-      <div className="h-72 w-full">
+      <div className="h-72 w-full text-slate-500 dark:text-slate-300">
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart data={chartData} margin={{ top: 10, right: 20, left: -10, bottom: 0 }}>
             <defs>
@@ -162,9 +162,21 @@ export function RecentRatingsAreaChart({
                 <stop offset="95%" stopColor="#0ea5e9" stopOpacity={0.05} />
               </linearGradient>
             </defs>
-            <CartesianGrid strokeDasharray="4 8" stroke="rgba(148, 163, 184, 0.35)" vertical={false} />
-            <XAxis dataKey="label" tickLine={false} axisLine={false} tick={{ fill: "#64748b", fontSize: 12 }} interval="preserveStartEnd" />
-            <YAxis domain={[1, 5]} tickLine={false} axisLine={false} tick={{ fill: "#64748b", fontSize: 12 }} allowDecimals />
+            <CartesianGrid strokeDasharray="4 8" stroke="currentColor" strokeOpacity={0.25} vertical={false} />
+            <XAxis
+              dataKey="label"
+              tickLine={false}
+              axisLine={false}
+              tick={{ fill: "currentColor", fontSize: 12 }}
+              interval="preserveStartEnd"
+            />
+            <YAxis
+              domain={[1, 5]}
+              tickLine={false}
+              axisLine={false}
+              tick={{ fill: "currentColor", fontSize: 12 }}
+              allowDecimals
+            />
             <Tooltip
               cursor={{ stroke: "rgba(14,165,233,0.2)", strokeWidth: 2 }}
               contentStyle={tooltipStyles}

--- a/syncback/components/dashboard/StatsGrid.module.css
+++ b/syncback/components/dashboard/StatsGrid.module.css
@@ -4,13 +4,17 @@
 
 .card {
   transition: transform 200ms ease, box-shadow 200ms ease;
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 255, 0.7));
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  background: light-dark(
+    linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 255, 0.7)),
+    linear-gradient(160deg, rgba(30, 41, 59, 0.92), rgba(15, 23, 42, 0.7))
+  );
+  box-shadow: light-dark(0 12px 30px rgba(15, 23, 42, 0.08), 0 14px 38px rgba(2, 6, 23, 0.45));
+  border: 1px solid light-dark(rgba(226, 232, 240, 0.7), rgba(71, 85, 105, 0.6));
 }
 
 .card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+  box-shadow: light-dark(0 18px 36px rgba(15, 23, 42, 0.12), 0 18px 42px rgba(8, 15, 35, 0.55));
 }
 
 .value {
@@ -27,7 +31,7 @@
 }
 
 .icon {
-  color: light-dark(var(--mantine-color-blue-4), var(--mantine-color-dark-3));
+  color: light-dark(var(--mantine-color-blue-4), rgba(125, 211, 252, 0.8));
 }
 
 .title {

--- a/syncback/components/home/sections/CallToActionSection.tsx
+++ b/syncback/components/home/sections/CallToActionSection.tsx
@@ -5,7 +5,7 @@ export function CallToActionSection() {
   return (
     <section
       id="get-started"
-      className="js-section-cta relative overflow-hidden rounded-[40px] border border-slate-200/80 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-10 text-white shadow-2xl shadow-slate-900/30"
+      className="js-section-cta relative overflow-hidden rounded-[40px] border border-slate-200/80 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-10 text-white shadow-2xl shadow-slate-900/30 dark:border-slate-700/80 dark:from-slate-900 dark:via-slate-900 dark:to-slate-900/90 dark:shadow-slate-900/60"
     >
       <div className="absolute inset-0 bg-noise opacity-30 mix-blend-overlay" aria-hidden />
       <div className="relative z-10 flex flex-col items-start gap-6 lg:flex-row lg:items-center lg:justify-between">
@@ -17,7 +17,7 @@ export function CallToActionSection() {
         </div>
         <Link
           href="#"
-          className="group inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-base font-semibold text-slate-900 shadow-xl transition hover:scale-[1.03]"
+          className="group inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-base font-semibold text-slate-900 shadow-xl transition hover:scale-[1.03] dark:bg-sky-500 dark:text-slate-900 dark:shadow-sky-500/40 dark:hover:bg-sky-400"
         >
           Create your free account
           <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" aria-hidden />

--- a/syncback/components/home/sections/HighlightsSection.tsx
+++ b/syncback/components/home/sections/HighlightsSection.tsx
@@ -26,19 +26,19 @@ export function HighlightsSection() {
   return (
     <section
       id="tour"
-      className="js-section-perks grid gap-10 rounded-[36px] border border-white/70 bg-white/70 p-10 shadow-xl shadow-slate-900/5 backdrop-blur lg:grid-cols-3"
+      className="js-section-perks grid gap-10 rounded-[36px] border border-white/70 bg-white/70 p-10 shadow-xl shadow-slate-900/5 backdrop-blur lg:grid-cols-3 dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40"
     >
       {highlights.map(({ icon: Icon, title, description }) => (
         <div
           key={title}
-          className="group flex flex-col gap-4 rounded-3xl border border-transparent bg-white/0 p-6 transition duration-500 hover:-translate-y-2 hover:border-slate-200 hover:bg-white/70"
+          className="group flex flex-col gap-4 rounded-3xl border border-transparent bg-white/0 p-6 transition duration-500 hover:-translate-y-2 hover:border-slate-200 hover:bg-white/70 dark:border-slate-700/60 dark:bg-slate-900/40 dark:hover:border-slate-600 dark:hover:bg-slate-900/70"
         >
-          <div className="w-fit rounded-full bg-slate-900/90 p-3 text-white shadow-lg shadow-slate-900/20 transition duration-500 group-hover:scale-110 group-hover:bg-slate-900">
+          <div className="w-fit rounded-full bg-slate-900/90 p-3 text-white shadow-lg shadow-slate-900/20 transition duration-500 group-hover:scale-110 group-hover:bg-slate-900 dark:bg-sky-500/20 dark:text-sky-300 dark:shadow-slate-900/40">
             <Icon className="h-5 w-5" aria-hidden />
           </div>
           <div className="space-y-2">
-            <h3 className="text-xl font-semibold text-slate-900">{title}</h3>
-            <p className="text-sm text-slate-600">{description}</p>
+            <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{title}</h3>
+            <p className="text-sm text-slate-600 dark:text-slate-300">{description}</p>
           </div>
         </div>
       ))}

--- a/syncback/components/home/sections/TestimonialsSection.tsx
+++ b/syncback/components/home/sections/TestimonialsSection.tsx
@@ -13,12 +13,12 @@ const testimonials = [
 
 export function TestimonialsSection() {
   return (
-    <section className="js-section-testimonials rounded-[32px] border border-white/70 bg-white/70 p-10 shadow-xl shadow-slate-900/5 backdrop-blur">
+    <section className="js-section-testimonials rounded-[32px] border border-white/70 bg-white/70 p-10 shadow-xl shadow-slate-900/5 backdrop-blur dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
       <div className="grid gap-10 lg:grid-cols-[0.8fr_1.2fr]">
         <div className="space-y-4">
-          <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Loved by teams</span>
-          <h2 className="text-3xl font-semibold text-slate-900 sm:text-4xl">Real teams, real-time improvements.</h2>
-          <p className="text-base text-slate-600">
+          <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Loved by teams</span>
+          <h2 className="text-3xl font-semibold text-slate-900 sm:text-4xl dark:text-slate-100">Real teams, real-time improvements.</h2>
+          <p className="text-base text-slate-600 dark:text-slate-300">
             SyncBack keeps the spotlight on customer joy. The more you listen, the faster you iterate.
           </p>
         </div>
@@ -26,12 +26,12 @@ export function TestimonialsSection() {
           {testimonials.map(({ quote, name, role }) => (
             <div
               key={name}
-              className="group flex h-full flex-col justify-between rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-lg shadow-slate-900/5 transition hover:-translate-y-2 hover:border-slate-300 hover:shadow-xl"
+              className="group flex h-full flex-col justify-between rounded-3xl border border-slate-200/80 bg-white/80 p-6 shadow-lg shadow-slate-900/5 transition hover:-translate-y-2 hover:border-slate-300 hover:shadow-xl dark:border-slate-700/80 dark:bg-slate-800/60 dark:text-slate-100 dark:shadow-slate-900/30 dark:hover:border-slate-600"
             >
-              <p className="text-base text-slate-700">{quote}</p>
+              <p className="text-base text-slate-700 dark:text-slate-200">{quote}</p>
               <div className="mt-6">
-                <p className="text-sm font-semibold text-slate-900">{name}</p>
-                <p className="text-xs text-slate-500">{role}</p>
+                <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{name}</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">{role}</p>
               </div>
             </div>
           ))}

--- a/syncback/components/home/sections/WorkflowSection.tsx
+++ b/syncback/components/home/sections/WorkflowSection.tsx
@@ -19,29 +19,29 @@ const steps = [
 export function WorkflowSection() {
   return (
     <section className="js-section-workflow grid gap-12 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
-      <div className="rounded-[32px] border border-white/70 bg-white/80 p-8 shadow-lg shadow-slate-900/10 backdrop-blur">
-        <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Workflow</span>
-        <h2 className="mt-4 text-3xl font-semibold text-slate-900 sm:text-4xl">From scan to inbox in a heartbeat.</h2>
-        <p className="mt-4 text-base text-slate-600">
+      <div className="rounded-[32px] border border-white/70 bg-white/80 p-8 shadow-lg shadow-slate-900/10 backdrop-blur dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
+        <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Workflow</span>
+        <h2 className="mt-4 text-3xl font-semibold text-slate-900 sm:text-4xl dark:text-slate-100">From scan to inbox in a heartbeat.</h2>
+        <p className="mt-4 text-base text-slate-600 dark:text-slate-300">
           SyncBack was designed for busy teams that value clarity over clutter. Every step is purposefully light so you can move
           from setup to actionable feedback in minutes.
         </p>
         <div className="mt-8 space-y-6">
           {steps.map((step, index) => (
             <div key={step.title} className="relative pl-12">
-              <div className="absolute left-0 top-1 flex h-10 w-10 items-center justify-center rounded-full bg-slate-900 text-white shadow-md shadow-slate-900/20">
+              <div className="absolute left-0 top-1 flex h-10 w-10 items-center justify-center rounded-full bg-slate-900 text-white shadow-md shadow-slate-900/20 dark:bg-sky-500/20 dark:text-sky-300 dark:shadow-slate-900/40">
                 <span className="text-base font-semibold">{index + 1}</span>
               </div>
-              <h3 className="text-lg font-semibold text-slate-900">{step.title}</h3>
-              <p className="mt-2 text-sm text-slate-600">{step.description}</p>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{step.title}</h3>
+              <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{step.description}</p>
             </div>
           ))}
         </div>
       </div>
       <div className="relative flex items-center justify-center">
-        <div className="absolute inset-0 -z-10 rounded-[40px] bg-gradient-to-br from-sky-200/70 via-indigo-200/40 to-transparent blur-2xl" aria-hidden />
-        <div className="relative w-full max-w-xl rounded-[40px] border border-white/80 bg-white/80 p-6 shadow-2xl shadow-slate-900/10 backdrop-blur">
-          <div className="rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6 text-white">
+        <div className="absolute inset-0 -z-10 rounded-[40px] bg-gradient-to-br from-sky-200/70 via-indigo-200/40 to-transparent blur-2xl dark:from-sky-500/10 dark:via-sky-500/0" aria-hidden />
+        <div className="relative w-full max-w-xl rounded-[40px] border border-white/80 bg-white/80 p-6 shadow-2xl shadow-slate-900/10 backdrop-blur dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
+          <div className="rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6 text-white dark:from-slate-900 dark:via-slate-900 dark:to-slate-900/90">
             <p className="text-sm uppercase tracking-[0.3em] text-white/60">Live session</p>
             <p className="mt-4 text-2xl font-semibold">Guest Feedback Board</p>
             <div className="mt-6 space-y-4 text-sm text-white/80">
@@ -53,7 +53,7 @@ export function WorkflowSection() {
               <div className="rounded-2xl bg-white/10 p-4">“Tables were spotless and QR flow was effortless.”</div>
             </div>
           </div>
-          <div className="mt-6 rounded-2xl border border-slate-200/70 bg-white/80 p-5 text-sm text-slate-600 shadow-sm backdrop-blur">
+          <div className="mt-6 rounded-2xl border border-slate-200/70 bg-white/80 p-5 text-sm text-slate-600 shadow-sm backdrop-blur dark:border-slate-700/70 dark:bg-slate-800/70 dark:text-slate-300 dark:shadow-slate-900/30">
             Your team is automatically looped in with actionable emails—no dashboards required.
           </div>
         </div>


### PR DESCRIPTION
## Summary
- refresh the home page CTA, highlights, testimonials, and workflow cards to mirror the “New feedback” dark mode surface
- restyle dashboard section wrappers, charts, and metrics grid so card borders, grids, and typography adapt cleanly in dark mode
- polish the recent feedback filters and modal surfaces for consistent dark mode contrast

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68dda98dc428832bbd99d0a01e589722