### PR TITLE
Adjust dashboard metrics grid layout

### DIFF
--- a/syncback/components/dashboard/StatsGrid.tsx
+++ b/syncback/components/dashboard/StatsGrid.tsx
@@ -93,7 +93,17 @@ export function StatsGrid({ metrics }: StatsGridProps) {
   });
   return (
     <div className={classes.root}>
-      <SimpleGrid cols={{ base: 1, xs: 2, md: 4 }}>{stats}</SimpleGrid>
+      <SimpleGrid
+        cols={{
+          base: 1,
+          xs: Math.min(2, metrics.length),
+          md: Math.min(3, metrics.length),
+          lg: Math.min(4, metrics.length),
+        }}
+        spacing="xl"
+      >
+        {stats}
+      </SimpleGrid>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- adjust the dashboard metrics grid to base column counts on the available metric cards
- add consistent spacing so the cards distribute evenly within the available width

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de4b290028832b8e4df0adfee5933a