### PR TITLE
Add GSAP SplitText animation to hero tagline

### DIFF
--- a/syncback/components/home/sections/HeroSection.tsx
+++ b/syncback/components/home/sections/HeroSection.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { ArrowRight, Mail, MessageCircle, QrCode, Sparkles, Star } from "lucide-react";
 
+import SplitText from "@/components/shared/SplitText";
+
 const floatingStats = [
   { label: "More in-moment feedback", value: "+42%" },
   { label: "Avg. setup time", value: "2 min" },
@@ -27,7 +29,8 @@ export function HeroSection({ isPulsing }: HeroSectionProps) {
             aria-hidden
           />
           <h1 className="relative text-4xl font-semibold tracking-tight text-slate-900 dark:text-slate-100 sm:text-5xl lg:text-6xl">
-            Close the feedback loop the moment customers scan with SyncBack.
+            Close the feedback loop the moment customers scan with{" "}
+            <SplitText text="SyncBack." tag="span" textAlign="left" />
           </h1>
         </div>
         <p className="max-w-xl text-lg text-slate-600 dark:text-slate-300 sm:text-xl">

--- a/syncback/components/shared/SplitText.tsx
+++ b/syncback/components/shared/SplitText.tsx
@@ -1,0 +1,205 @@
+import React, { useEffect, useRef, useState } from "react";
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+import { SplitText as GSAPSplitText } from "gsap/SplitText";
+import { useGSAP } from "@gsap/react";
+
+gsap.registerPlugin(ScrollTrigger, GSAPSplitText, useGSAP);
+
+export interface SplitTextProps {
+  text: string;
+  className?: string;
+  delay?: number;
+  duration?: number;
+  ease?: string | ((t: number) => number);
+  splitType?: "chars" | "words" | "lines" | "words, chars";
+  from?: gsap.TweenVars;
+  to?: gsap.TweenVars;
+  threshold?: number;
+  rootMargin?: string;
+  tag?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "p" | "span";
+  textAlign?: React.CSSProperties["textAlign"];
+  onLetterAnimationComplete?: () => void;
+}
+
+const SplitText: React.FC<SplitTextProps> = ({
+  text,
+  className = "",
+  delay = 100,
+  duration = 0.6,
+  ease = "power3.out",
+  splitType = "chars",
+  from = { opacity: 0, y: 40 },
+  to = { opacity: 1, y: 0 },
+  threshold = 0.1,
+  rootMargin = "-100px",
+  tag = "p",
+  textAlign = "center",
+  onLetterAnimationComplete,
+}) => {
+  const ref = useRef<HTMLElement>(null);
+  const [fontsLoaded, setFontsLoaded] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (document.fonts.status === "loaded") {
+      setFontsLoaded(true);
+    } else {
+      document.fonts.ready.then(() => {
+        setFontsLoaded(true);
+      });
+    }
+  }, []);
+
+  useGSAP(
+    () => {
+      if (!ref.current || !text || !fontsLoaded) return;
+      const el = ref.current as HTMLElement & {
+        _rbsplitInstance?: GSAPSplitText;
+      };
+
+      if (el._rbsplitInstance) {
+        try {
+          el._rbsplitInstance.revert();
+        } catch {}
+        el._rbsplitInstance = undefined;
+      }
+
+      const startPct = (1 - threshold) * 100;
+      const marginMatch = /^(-?\d+(?:\.\d+)?)(px|em|rem|%)?$/.exec(rootMargin);
+      const marginValue = marginMatch ? parseFloat(marginMatch[1]) : 0;
+      const marginUnit = marginMatch ? marginMatch[2] || "px" : "px";
+      const sign =
+        marginValue === 0
+          ? ""
+          : marginValue < 0
+            ? `-=${Math.abs(marginValue)}${marginUnit}`
+            : `+=${marginValue}${marginUnit}`;
+      const start = `top ${startPct}%${sign}`;
+      let targets: Element[] = [];
+      const assignTargets = (self: GSAPSplitText) => {
+        if (splitType.includes("chars") && (self as GSAPSplitText).chars?.length)
+          targets = (self as GSAPSplitText).chars;
+        if (!targets.length && splitType.includes("words") && self.words.length) targets = self.words;
+        if (!targets.length && splitType.includes("lines") && self.lines.length) targets = self.lines;
+        if (!targets.length) targets = self.chars || self.words || self.lines;
+      };
+      const splitInstance = new GSAPSplitText(el, {
+        type: splitType,
+        smartWrap: true,
+        autoSplit: splitType === "lines",
+        linesClass: "split-line",
+        wordsClass: "split-word",
+        charsClass: "split-char",
+        reduceWhiteSpace: false,
+        onSplit: (self: GSAPSplitText) => {
+          assignTargets(self);
+          return gsap.fromTo(
+            targets,
+            { ...from },
+            {
+              ...to,
+              duration,
+              ease,
+              stagger: delay / 1000,
+              scrollTrigger: {
+                trigger: el,
+                start,
+                once: true,
+                fastScrollEnd: true,
+                anticipatePin: 0.4,
+              },
+              onComplete: () => {
+                onLetterAnimationComplete?.();
+              },
+              willChange: "transform, opacity",
+              force3D: true,
+            }
+          );
+        },
+      });
+      el._rbsplitInstance = splitInstance;
+      return () => {
+        ScrollTrigger.getAll().forEach((st) => {
+          if (st.trigger === el) st.kill();
+        });
+        try {
+          splitInstance.revert();
+        } catch {}
+        el._rbsplitInstance = undefined;
+      };
+    },
+    {
+      dependencies: [
+        text,
+        delay,
+        duration,
+        ease,
+        splitType,
+        JSON.stringify(from),
+        JSON.stringify(to),
+        threshold,
+        rootMargin,
+        fontsLoaded,
+        onLetterAnimationComplete,
+      ],
+      scope: ref,
+    }
+  );
+
+  const renderTag = () => {
+    const style: React.CSSProperties = {
+      textAlign,
+      wordWrap: "break-word",
+      willChange: "transform, opacity",
+    };
+    const classes = `split-parent overflow-hidden inline-block whitespace-normal ${className}`;
+    switch (tag) {
+      case "h1":
+        return (
+          <h1 ref={ref} style={style} className={classes}>
+            {text}
+          </h1>
+        );
+      case "h2":
+        return (
+          <h2 ref={ref} style={style} className={classes}>
+            {text}
+          </h2>
+        );
+      case "h3":
+        return (
+          <h3 ref={ref} style={style} className={classes}>
+            {text}
+          </h3>
+        );
+      case "h4":
+        return (
+          <h4 ref={ref} style={style} className={classes}>
+            {text}
+          </h4>
+        );
+      case "h5":
+        return (
+          <h5 ref={ref} style={style} className={classes}>
+            {text}
+          </h5>
+        );
+      case "h6":
+        return (
+          <h6 ref={ref} style={style} className={classes}>
+            {text}
+          </h6>
+        );
+      default:
+        return (
+          <p ref={ref} style={style} className={classes}>
+            {text}
+          </p>
+        );
+    }
+  };
+
+  return renderTag();
+};
+
+export default SplitText;

--- a/syncback/package-lock.json
+++ b/syncback/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.33.1",
+        "@gsap/react": "^2.1.2",
         "@internationalized/date": "^3.9.0",
         "@mantine/core": "^7.14.2",
         "@mantine/hooks": "^7.14.2",
@@ -838,6 +839,16 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@gsap/react": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@gsap/react/-/react-2.1.2.tgz",
+      "integrity": "sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==",
+      "license": "SEE LICENSE AT https://gsap.com/standard-license",
+      "peerDependencies": {
+        "gsap": "^3.12.5",
+        "react": ">=17"
       }
     },
     "node_modules/@humanfs/core": {

--- a/syncback/package.json
+++ b/syncback/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.33.1",
+    "@gsap/react": "^2.1.2",
     "@internationalized/date": "^3.9.0",
     "@mantine/core": "^7.14.2",
     "@mantine/hooks": "^7.14.2",


### PR DESCRIPTION
## Summary
- add a reusable GSAP-powered SplitText component for scroll-triggered text animations
- apply the SplitText animation to the "SyncBack." word in the hero section headline
- include the @gsap/react dependency required for the animation hook

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de572d5ac8832b8c1bf2d76c98fc2c