### PR TITLE
Fix dashboard headers usage and animate title

### DIFF
--- a/syncback/app/(dashboard)/dashboard/sections/PerformanceOverviewSection.tsx
+++ b/syncback/app/(dashboard)/dashboard/sections/PerformanceOverviewSection.tsx
@@ -1,5 +1,6 @@
 import type { StatsGridProps } from "./types";
 import { StatsGrid } from "@/components/dashboard/StatsGrid";
+import SplitText from "@/components/shared/SplitText";
 
 export type PerformanceOverviewSectionProps = {
   businessName: string;
@@ -11,7 +12,12 @@ export function PerformanceOverviewSection({ businessName, metrics }: Performanc
     <section className="space-y-6">
       <div className="space-y-2">
         <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">Performance overview</p>
-        <h1 className="text-3xl font-semibold leading-tight text-slate-950 dark:text-slate-100 sm:text-4xl lg:text-5xl">Insights for {businessName}</h1>
+        <SplitText
+          text={`Insights for ${businessName}`}
+          tag="h1"
+          textAlign="left"
+          className="text-3xl font-semibold leading-tight text-slate-950 dark:text-slate-100 sm:text-4xl lg:text-5xl"
+        />
         <p className="max-w-2xl text-base text-slate-600 dark:text-slate-300 sm:text-lg">
           Track how guests feel about every experience and spot momentum in your ratings at a glance.
         </p>

--- a/syncback/app/(dashboard)/settings/actions.ts
+++ b/syncback/app/(dashboard)/settings/actions.ts
@@ -46,7 +46,7 @@ export async function resolveAppUrl() {
     return envUrl.replace(/\/$/, "");
   }
 
-  const headerList = headers();
+  const headerList = await headers();
   const host = headerList.get("host");
   if (host) {
     const protocol = headerList.get("x-forwarded-proto") ?? "https";


### PR DESCRIPTION
## Summary
- await `headers()` in the dashboard settings action to avoid sync access errors in Next.js
- animate the dashboard title with the SplitText component for the business name

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de5a116ca8832b85bd4dc3b1b1407b