### PR TITLE
Adjust highlights scroll stack to use window scroll

### DIFF
--- a/syncback/components/home/ScrollStack.tsx
+++ b/syncback/components/home/ScrollStack.tsx
@@ -331,20 +331,25 @@ const ScrollStack: React.FC<ScrollStackProps> = ({
     updateCardTransforms,
   ]);
 
+  const containerClassName = `relative w-full ${
+    useWindowScroll ? "overflow-visible" : "h-full overflow-y-auto overflow-x-visible"
+  } ${className}`.trim();
+
+  const containerStyle = useWindowScroll
+    ? undefined
+    : {
+        overscrollBehavior: "contain" as const,
+        WebkitOverflowScrolling: "touch" as const,
+        scrollBehavior: "smooth" as const,
+        WebkitTransform: "translateZ(0)" as const,
+        transform: "translateZ(0)" as const,
+        willChange: "scroll-position" as const,
+      };
+
   return (
-    <div
-      className={`relative w-full h-full overflow-y-auto overflow-x-visible ${className}`.trim()}
-      ref={scrollerRef}
-      style={{
-        overscrollBehavior: "contain",
-        WebkitOverflowScrolling: "touch",
-        scrollBehavior: "smooth",
-        WebkitTransform: "translateZ(0)",
-        transform: "translateZ(0)",
-        willChange: "scroll-position",
-      }}
-    >
-      <div className="scroll-stack-inner pt-[20vh] px-20 pb-[50rem] min-h-screen">{children}
+    <div className={containerClassName} ref={useWindowScroll ? undefined : scrollerRef} style={containerStyle}>
+      <div className="scroll-stack-inner pt-[20vh] px-20 pb-[50rem] min-h-screen">
+        {children}
         {/* Spacer so the last pin can release cleanly */}
         <div className="scroll-stack-end w-full h-px" />
       </div>

--- a/syncback/components/home/sections/HighlightsSection.tsx
+++ b/syncback/components/home/sections/HighlightsSection.tsx
@@ -32,7 +32,15 @@ export function HighlightsSection() {
       id="tour"
       className="js-section-perks rounded-[36px] border border-white/70 bg-white/70 p-6 shadow-xl shadow-slate-900/5 backdrop-blur dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40"
     >
-      <ScrollStack className="h-[680px] max-h-[80vh] rounded-[28px] bg-transparent">
+      <ScrollStack
+        className="rounded-[28px] bg-transparent"
+        useWindowScroll
+        itemDistance={180}
+        itemStackDistance={20}
+        stackPosition="35%"
+        baseScale={0.65}
+        rotationAmount={0.4}
+      >
         {highlights.map(({ icon: Icon, title, description }) => (
           <ScrollStackItem
             key={title}


### PR DESCRIPTION
## Summary
- update the highlights scroll stack to use window scrolling and updated stacking offsets
- allow the ScrollStack component to avoid rendering a nested scroll container when window scrolling is enabled

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de81758d18832bbb4e001fcf93c6a3