### PR TITLE
Fix ScrollStack container for window scrolling

### DIFF
--- a/syncback/components/home/ScrollStack.tsx
+++ b/syncback/components/home/ScrollStack.tsx
@@ -331,18 +331,26 @@ const ScrollStack: React.FC<ScrollStackProps> = ({
     updateCardTransforms,
   ]);
 
+  const containerClassName = useWindowScroll
+    ? `relative w-full overflow-visible ${className}`.trim()
+    : `relative w-full h-full overflow-y-auto overflow-x-visible ${className}`.trim();
+
+  const containerStyle = useWindowScroll
+    ? undefined
+    : {
+        overscrollBehavior: "contain" as const,
+        WebkitOverflowScrolling: "touch" as const,
+        scrollBehavior: "smooth" as const,
+        WebkitTransform: "translateZ(0)" as const,
+        transform: "translateZ(0)" as const,
+        willChange: "scroll-position" as const,
+      };
+
   return (
     <div
-      className={`relative w-full h-full overflow-y-auto overflow-x-visible ${className}`.trim()}
-      ref={scrollerRef}
-      style={{
-        overscrollBehavior: "contain",
-        WebkitOverflowScrolling: "touch",
-        scrollBehavior: "smooth",
-        WebkitTransform: "translateZ(0)",
-        transform: "translateZ(0)",
-        willChange: "scroll-position",
-      }}
+      className={containerClassName}
+      ref={useWindowScroll ? undefined : scrollerRef}
+      style={containerStyle}
     >
       <div className="scroll-stack-inner pt-[20vh] px-20 pb-[50rem] min-h-screen">
         {children}


### PR DESCRIPTION
## Summary
- adjust ScrollStack container classes when using window scrolling so cards animate as intended
- limit scroll-specific inline styles to the internal scroller configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de97333340832b9627705c1cb6e292