### PR TITLE
Adjust scroll stack viewport for highlights section

### DIFF
--- a/syncback/components/home/ScrollStack.tsx
+++ b/syncback/components/home/ScrollStack.tsx
@@ -335,6 +335,10 @@ const ScrollStack: React.FC<ScrollStackProps> = ({
     ? `relative w-full overflow-visible ${className}`.trim()
     : `relative w-full h-full overflow-y-auto overflow-x-visible ${className}`.trim();
 
+  const innerClassName = useWindowScroll
+    ? "scroll-stack-inner flex flex-col gap-8 pt-[20vh] px-20 pb-[40vh] min-h-screen"
+    : "scroll-stack-inner flex flex-col gap-8 px-6 py-10";
+
   const containerStyle = useWindowScroll
     ? undefined
     : {
@@ -352,7 +356,7 @@ const ScrollStack: React.FC<ScrollStackProps> = ({
       ref={useWindowScroll ? undefined : scrollerRef}
       style={containerStyle}
     >
-      <div className="scroll-stack-inner pt-[20vh] px-20 pb-[50rem] min-h-screen">
+      <div className={innerClassName}>
         {children}
         {/* Spacer so the last pin can release cleanly */}
         <div className="scroll-stack-end w-full h-px" />

--- a/syncback/components/home/sections/HighlightsSection.tsx
+++ b/syncback/components/home/sections/HighlightsSection.tsx
@@ -33,8 +33,7 @@ export function HighlightsSection() {
       className="js-section-perks rounded-[36px] border border-white/70 bg-white/70 p-6 shadow-xl shadow-slate-900/5 backdrop-blur dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40"
     >
       <ScrollStack
-        className="rounded-[28px] bg-transparent"
-        useWindowScroll
+        className="rounded-[28px] bg-transparent h-[28rem] max-h-[28rem]"
         itemDistance={180}
         itemStackDistance={20}
         stackPosition="35%"


### PR DESCRIPTION
## Summary
- tighten the ScrollStack layout so the inner container uses a compact column layout when it manages its own scrolling
- constrain the highlights ScrollStack to a fixed-height viewport so the cards stack and unstack while scrolling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68debc6eb480832bb3ac2e489634aea6