### PR TITLE
Add animated count-up effect to dashboard metrics

### DIFF
--- a/syncback/components/dashboard/StatsGrid.tsx
+++ b/syncback/components/dashboard/StatsGrid.tsx
@@ -11,6 +11,7 @@ import {
   type TablerIconsProps,
 } from "@tabler/icons-react";
 import { Group, Paper, SimpleGrid, Text } from "@mantine/core";
+import CountUp from "@/components/shared/CountUp";
 import classes from "./StatsGrid.module.css";
 
 const icons = {
@@ -61,6 +62,14 @@ export function StatsGrid({ metrics }: StatsGridProps) {
         ? `${classes.diffBadge} ${classes.diffPositive}`
         : `${classes.diffBadge} ${classes.diffNegative}`;
 
+    const numericMatch = stat.value.match(/-?\d[\d,]*(?:\.\d+)?/);
+    const numericPortion = numericMatch?.[0] ?? null;
+    const prefix = numericMatch && numericMatch.index ? stat.value.slice(0, numericMatch.index) : "";
+    const suffix = numericMatch ? stat.value.slice((numericMatch.index ?? 0) + numericMatch[0].length) : "";
+    const numericValue = numericPortion !== null ? Number(numericPortion.replace(/,/g, "")) : undefined;
+    const hasThousandSeparator = numericPortion?.includes(",") ?? false;
+    const shouldAnimate = typeof numericValue === "number" && Number.isFinite(numericValue);
+
     return (
       <Paper withBorder p="xl" radius="lg" key={stat.title} className={classes.card}>
         <div className={classes.header}>
@@ -78,7 +87,22 @@ export function StatsGrid({ metrics }: StatsGridProps) {
         </div>
 
         <Group align="flex-end" justify="space-between" className={classes.metricRow}>
-          <Text className={classes.value}>{stat.value}</Text>
+          <Text className={classes.value}>
+            {shouldAnimate ? (
+              <>
+                {prefix}
+                <CountUp
+                  to={numericValue ?? 0}
+                  from={0}
+                  duration={1.4}
+                  separator={hasThousandSeparator ? "," : ""}
+                />
+                {suffix}
+              </>
+            ) : (
+              stat.value
+            )}
+          </Text>
           <div className={diffClassName}>
             <DiffIcon size={16} stroke={1.5} />
             <span>{Math.abs(stat.diff)}%</span>

--- a/syncback/components/shared/CountUp.tsx
+++ b/syncback/components/shared/CountUp.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useInView, useMotionValue, useSpring } from "motion/react";
+
+interface CountUpProps {
+  to: number;
+  from?: number;
+  direction?: "up" | "down";
+  delay?: number;
+  duration?: number;
+  className?: string;
+  startWhen?: boolean;
+  separator?: string;
+  onStart?: () => void;
+  onEnd?: () => void;
+}
+
+export default function CountUp({
+  to,
+  from = 0,
+  direction = "up",
+  delay = 0,
+  duration = 2,
+  className = "",
+  startWhen = true,
+  separator = "",
+  onStart,
+  onEnd,
+}: CountUpProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const motionValue = useMotionValue(direction === "down" ? to : from);
+
+  const damping = 20 + 40 * (1 / duration);
+  const stiffness = 100 * (1 / duration);
+
+  const springValue = useSpring(motionValue, {
+    damping,
+    stiffness,
+  });
+
+  const isInView = useInView(ref, { once: true, margin: "0px" });
+
+  const getDecimalPlaces = (num: number): number => {
+    const str = num.toString();
+    if (str.includes(".")) {
+      const decimals = str.split(".")[1];
+      if (parseInt(decimals) !== 0) {
+        return decimals.length;
+      }
+    }
+    return 0;
+  };
+
+  const maxDecimals = Math.max(getDecimalPlaces(from), getDecimalPlaces(to));
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.textContent = String(direction === "down" ? to : from);
+    }
+  }, [from, to, direction]);
+
+  useEffect(() => {
+    if (isInView && startWhen) {
+      if (typeof onStart === "function") {
+        onStart();
+      }
+
+      const timeoutId = setTimeout(() => {
+        motionValue.set(direction === "down" ? from : to);
+      }, delay * 1000);
+
+      const durationTimeoutId = setTimeout(
+        () => {
+          if (typeof onEnd === "function") {
+            onEnd();
+          }
+        },
+        delay * 1000 + duration * 1000,
+      );
+
+      return () => {
+        clearTimeout(timeoutId);
+        clearTimeout(durationTimeoutId);
+      };
+    }
+  }, [isInView, startWhen, motionValue, direction, from, to, delay, onStart, onEnd, duration]);
+
+  useEffect(() => {
+    const unsubscribe = springValue.on("change", (latest) => {
+      if (ref.current) {
+        const hasDecimals = maxDecimals > 0;
+
+        const options: Intl.NumberFormatOptions = {
+          useGrouping: !!separator,
+          minimumFractionDigits: hasDecimals ? maxDecimals : 0,
+          maximumFractionDigits: hasDecimals ? maxDecimals : 0,
+        };
+
+        const formattedNumber = Intl.NumberFormat("en-US", options).format(latest);
+
+        ref.current.textContent = separator ? formattedNumber.replace(/,/g, separator) : formattedNumber;
+      }
+    });
+
+    return () => unsubscribe();
+  }, [springValue, separator, maxDecimals]);
+
+  return <span className={className} ref={ref} />;
+}

--- a/syncback/package-lock.json
+++ b/syncback/package-lock.json
@@ -22,6 +22,7 @@
         "convex": "^1.27.3",
         "gsap": "^3.13.0",
         "lucide-react": "^0.544.0",
+        "motion": "^12.23.22",
         "next": "15.5.4",
         "qrcode-generator": "^1.5.2",
         "react": "19.1.0",
@@ -6742,6 +6743,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.22",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.22.tgz",
+      "integrity": "sha512-ZgGvdxXCw55ZYvhoZChTlG6pUuehecgvEAJz0BHoC5pQKW1EC5xf1Mul1ej5+ai+pVY0pylyFfdl45qnM1/GsA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.21",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -8087,6 +8115,47 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.23.22",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.22.tgz",
+      "integrity": "sha512-iSq6X9vLHbeYwmHvhK//+U74ROaPnZmBuy60XZzqNl0QtZkWfoZyMDHYnpKuWFv0sNMqHgED8aCXk94LCoQPGg==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.23.22",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.21",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.21.tgz",
+      "integrity": "sha512-5xDXx/AbhrfgsQmSE7YESMn4Dpo6x5/DTZ4Iyy4xqDvVHWvFVoV+V2Ri2S/ksx+D40wrZ7gPYiMWshkdoqNgNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/syncback/package.json
+++ b/syncback/package.json
@@ -23,6 +23,7 @@
     "convex": "^1.27.3",
     "gsap": "^3.13.0",
     "lucide-react": "^0.544.0",
+    "motion": "^12.23.22",
     "next": "15.5.4",
     "qrcode-generator": "^1.5.2",
     "react": "19.1.0",


### PR DESCRIPTION
## Summary
- add a reusable client-side CountUp component backed by Motion springs
- integrate CountUp into the dashboard stats grid so metric values animate on load
- add the Motion dependency to support the new animation logic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dece61fd98832babb8af8208f7efac