### PR TITLE
Update marketing links and auth redirects

### DIFF
--- a/syncback/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/syncback/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -3,7 +3,7 @@ import { SignIn } from "@clerk/nextjs";
 export default function SignInPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-[#f5f7ff] p-6">
-      <SignIn routing="path" signUpUrl="/sign-up" />
+      <SignIn routing="path" signUpUrl="/sign-up" afterSignInUrl="/dashboard" />
     </div>
   );
 }

--- a/syncback/app/(public)/[businessId]/feedback/success/page.tsx
+++ b/syncback/app/(public)/[businessId]/feedback/success/page.tsx
@@ -109,7 +109,7 @@ export default async function FeedbackSuccessPage({
               Share another response
             </Link>
             <Link
-              href="https://syncback.app"
+              href="/"
               className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300/70 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-400"
             >
               Learn more about SyncBack

--- a/syncback/components/home/sections/CallToActionSection.tsx
+++ b/syncback/components/home/sections/CallToActionSection.tsx
@@ -16,7 +16,7 @@ export function CallToActionSection() {
           </p>
         </div>
         <Link
-          href="#"
+          href="/sign-up"
           className="group inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-base font-semibold text-slate-900 shadow-xl transition hover:scale-[1.03] dark:bg-sky-500 dark:text-slate-900 dark:shadow-sky-500/40 dark:hover:bg-sky-400"
         >
           Create your free account

--- a/syncback/components/home/sections/HeroSection.tsx
+++ b/syncback/components/home/sections/HeroSection.tsx
@@ -39,7 +39,7 @@ export function HeroSection({ isPulsing }: HeroSectionProps) {
         </p>
         <div className="flex flex-col gap-4 sm:flex-row">
           <Link
-            href="#get-started"
+            href="/sign-up"
             className="group inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-base font-medium text-white shadow-lg shadow-slate-900/20 transition hover:scale-[1.02] hover:bg-slate-800 dark:bg-sky-500 dark:text-slate-900 dark:shadow-sky-500/30 dark:hover:bg-sky-400"
           >
             Start for free


### PR DESCRIPTION
## Summary
- update the hero and CTA buttons to route users to the sign-up page
- point the "learn more" link on the feedback success screen to the home page
- send newly signed-in users directly to the dashboard

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68deda5d4e8c832ba04b742ddb4203a8