### PR TITLE
Fix lint warnings in RecentFeedbackTable meta augmentation

### DIFF
--- a/syncback/components/dashboard/RecentFeedbackTable.tsx
+++ b/syncback/components/dashboard/RecentFeedbackTable.tsx
@@ -61,10 +61,14 @@ const rangeLabelFormatter = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
 });
 
+type ColumnFilterVariant<TData extends RowData, TValue> =
+  TData extends RowData
+    ? (TValue extends unknown ? "text" | "select" | "range" : never)
+    : never;
+
 declare module "@tanstack/react-table" {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData extends RowData, TValue> {
-    filterVariant?: "text" | "select" | "range";
+    filterVariant?: ColumnFilterVariant<TData, TValue>;
     filterPlaceholder?: string;
   }
 }


### PR DESCRIPTION
## Summary
- add a typed helper for ColumnMeta filter variants so the module augmentation no longer needs an eslint-disable comment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dedd1ceae4832babab39464c6f3e9c