### PR TITLE
Handle Convex errors in dashboard page

### DIFF
--- a/syncback/app/(dashboard)/dashboard/sections/PerformanceOverviewSection.tsx
+++ b/syncback/app/(dashboard)/dashboard/sections/PerformanceOverviewSection.tsx
@@ -5,9 +5,10 @@ import SplitText from "@/components/shared/SplitText";
 export type PerformanceOverviewSectionProps = {
   businessName: string;
   metrics: StatsGridProps["metrics"];
+  hasConvexError?: boolean;
 };
 
-export function PerformanceOverviewSection({ businessName, metrics }: PerformanceOverviewSectionProps) {
+export function PerformanceOverviewSection({ businessName, metrics, hasConvexError = false }: PerformanceOverviewSectionProps) {
   return (
     <section className="space-y-6">
       <div className="space-y-2">
@@ -22,9 +23,22 @@ export function PerformanceOverviewSection({ businessName, metrics }: Performanc
           Track how guests feel about every experience and spot momentum in your ratings at a glance.
         </p>
       </div>
-      <div className="overflow-hidden rounded-[32px] border border-white/60 bg-white/70 shadow-xl backdrop-blur dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
-        <StatsGrid metrics={metrics} />
-      </div>
+      {hasConvexError ? (
+        <div
+          className="overflow-hidden rounded-[32px] border border-red-200 bg-red-50/90 p-6 text-sm text-red-700 shadow-xl backdrop-blur dark:border-red-900/70 dark:bg-red-950/40 dark:text-red-200"
+          role="alert"
+        >
+          <p className="font-semibold">Data temporarily unavailable</p>
+          <p className="mt-1 text-red-600 dark:text-red-300">
+            We ran into a problem talking to Convex. Double-check your environment variables and try again once everything looks
+            good.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-[32px] border border-white/60 bg-white/70 shadow-xl backdrop-blur dark:border-slate-700/80 dark:bg-slate-900/60 dark:shadow-slate-900/40">
+          <StatsGrid metrics={metrics} />
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- wrap dashboard data queries in try/catch blocks so failures are logged and surfaced to the UI
- pass a Convex error flag into the dashboard layout and render an inline alert when data loading fails

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6b8ecd668832bb4537e032071757f