### PR TITLE
Fix viewport metadata export and adjust Convex pagination

### DIFF
--- a/syncback/app/layout.tsx
+++ b/syncback/app/layout.tsx
@@ -1,5 +1,5 @@
 import "@mantine/core/styles.css";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Poppins } from "next/font/google";
 import { ColorSchemeScript } from "@mantine/core";
 
@@ -62,11 +62,12 @@ export const metadata: Metadata = {
     description: siteDescription,
     images: ["/og-image.svg"],
   },
-  viewport: {
-    width: "device-width",
-    initialScale: 1,
-    maximumScale: 5,
-  },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 5,
 };
 
 const structuredData = {
@@ -127,8 +128,10 @@ export default function RootLayout({
         />
       </head>
       <body className={`${poppins.className} antialiased`} suppressHydrationWarning>
-        <Providers>{children}
-        <Analytics /></Providers>
+        <Providers>
+          {children}
+          <Analytics />
+        </Providers>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- move viewport configuration from root metadata to the dedicated viewport export
- update the root provider tree to avoid JSX formatting issues
- replace the dashboard data query's second paginated request with a take-based query to satisfy Convex constraints

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6be4a4e20832b9b76ea009fba785d