### PR TITLE
Add half-star support to rating distribution chart

### DIFF
--- a/syncback/components/dashboard/RatingDistributionChart.tsx
+++ b/syncback/components/dashboard/RatingDistributionChart.tsx
@@ -14,6 +14,7 @@ import {
 type RatingDistributionDatum = {
   segment: string;
   value: number;
+  label: string;
 };
 
 type RatingDistributionChartProps = {
@@ -66,6 +67,20 @@ export function RatingDistributionChart({ data }: RatingDistributionChartProps) 
         <Tooltip
           contentStyle={tooltipStyles}
           formatter={(value: number) => [`${value}%`, "Share"]}
+          labelFormatter={(label: string, payload) => {
+            const firstDatum = payload?.[0]?.payload as RatingDistributionDatum | undefined;
+            if (firstDatum) {
+              return firstDatum.label;
+            }
+            const parsedLabel = Number.parseFloat(label);
+            if (Number.isFinite(parsedLabel)) {
+              const isSingular = Math.abs(parsedLabel - 1) < 1e-8;
+              return `${Number.isInteger(parsedLabel) ? parsedLabel : parsedLabel.toFixed(1)} ${
+                isSingular ? "Star" : "Stars"
+              }`;
+            }
+            return label;
+          }}
           labelStyle={{
             color: "rgba(226, 232, 240, 0.8)",
             fontSize: 12,


### PR DESCRIPTION
## Summary
- expand backend rating buckets to support 0.5 star increments and migrate legacy data
- update dashboard rating distribution data to expose half-star labels for the chart
- enhance the chart tooltip to render the new half-star labels cleanly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6c2cb6178832b9e84683a7f865ff6