### PR TITLE
Add auto refresh and manual reload controls to dashboard

### DIFF
--- a/syncback/app/(dashboard)/dashboard/DashboardContent.tsx
+++ b/syncback/app/(dashboard)/dashboard/DashboardContent.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  PerformanceOverviewSection,
+  type PerformanceOverviewSectionProps,
+} from "./sections/PerformanceOverviewSection";
+import {
+  RatingDistributionSection,
+  type RatingDistributionSectionProps,
+} from "./sections/RatingDistributionSection";
+import { RatingTrendSection, type RatingTrendSectionProps } from "./sections/RatingTrendSection";
+import { RecentFeedbackSection, type RecentFeedbackSectionProps } from "./sections/RecentFeedbackSection";
+import { RecentRatingsSection, type RecentRatingsSectionProps } from "./sections/RecentRatingsSection";
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+type DashboardData = {
+  metrics: PerformanceOverviewSectionProps["metrics"];
+  ratingTrend: RatingTrendSectionProps["data"];
+  ratingDistribution: RatingDistributionSectionProps["data"];
+  recentRatings: RecentRatingsSectionProps["ratings"];
+  recentFeedback: RecentFeedbackSectionProps["feedback"];
+  totalFeedbackCount: number;
+} | null;
+
+type DashboardResponse = {
+  businessName: string;
+  dashboardData: DashboardData;
+  hasConvexError: boolean;
+};
+
+export type DashboardContentProps = {
+  initialBusinessName: string;
+  initialDashboardData: DashboardData;
+  initialHasConvexError: boolean;
+};
+
+export function DashboardContent({
+  initialBusinessName,
+  initialDashboardData,
+  initialHasConvexError,
+}: DashboardContentProps) {
+  const [businessName, setBusinessName] = useState(initialBusinessName);
+  const [dashboardData, setDashboardData] = useState<DashboardData>(initialDashboardData);
+  const [hasConvexError, setHasConvexError] = useState(initialHasConvexError);
+  const [isReloading, setIsReloading] = useState(false);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
+
+  const activeRequest = useRef<AbortController | null>(null);
+  const isMounted = useRef(true);
+  const isReloadingRef = useRef(false);
+
+  useEffect(() => {
+    if (!initialHasConvexError && initialDashboardData) {
+      setLastUpdatedAt(Date.now());
+    }
+  }, [initialDashboardData, initialHasConvexError]);
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false;
+      activeRequest.current?.abort();
+    };
+  }, []);
+
+  const refreshDashboard = useCallback(async () => {
+    if (isReloadingRef.current) {
+      return;
+    }
+
+    const controller = new AbortController();
+    activeRequest.current?.abort();
+    activeRequest.current = controller;
+    isReloadingRef.current = true;
+    setIsReloading(true);
+
+    try {
+      const response = await fetch("/api/dashboard/data", {
+        cache: "no-store",
+        method: "GET",
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to refresh dashboard data: ${response.statusText}`);
+      }
+
+      const payload = (await response.json()) as DashboardResponse;
+
+      if (!isMounted.current) {
+        return;
+      }
+
+      setBusinessName(payload.businessName || "Your business");
+      setHasConvexError(Boolean(payload.hasConvexError));
+
+      if (!payload.hasConvexError) {
+        setDashboardData(payload.dashboardData ?? null);
+        setLastUpdatedAt(Date.now());
+      } else if (payload.dashboardData) {
+        setDashboardData(payload.dashboardData);
+      }
+    } catch (error) {
+      if ((error as Error).name === "AbortError") {
+        return;
+      }
+
+      console.error("Failed to refresh dashboard data", error);
+
+      if (isMounted.current) {
+        setHasConvexError(true);
+      }
+    } finally {
+      if (isMounted.current) {
+        setIsReloading(false);
+      }
+
+      if (activeRequest.current === controller) {
+        activeRequest.current = null;
+      }
+
+      isReloadingRef.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      if (document.visibilityState === "hidden") {
+        return;
+      }
+
+      refreshDashboard();
+    }, ONE_HOUR_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [refreshDashboard]);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+
+      if (lastUpdatedAt === null) {
+        refreshDashboard();
+        return;
+      }
+
+      if (Date.now() - lastUpdatedAt >= ONE_HOUR_MS) {
+        refreshDashboard();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [lastUpdatedAt, refreshDashboard]);
+
+  const totalFeedbackCount = dashboardData?.totalFeedbackCount ?? 0;
+
+  const lastUpdatedAtMemo = useMemo(() => lastUpdatedAt, [lastUpdatedAt]);
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-6 pb-24 pt-20 sm:px-8 lg:px-12">
+      <PerformanceOverviewSection
+        businessName={businessName}
+        metrics={dashboardData?.metrics ?? []}
+        hasConvexError={hasConvexError}
+        onReload={refreshDashboard}
+        isReloading={isReloading}
+        lastUpdatedAt={lastUpdatedAtMemo}
+        autoRefreshIntervalMs={ONE_HOUR_MS}
+      />
+      <div className="grid gap-10 lg:grid-cols-2">
+        <RatingTrendSection data={dashboardData?.ratingTrend ?? []} />
+        <RatingDistributionSection data={dashboardData?.ratingDistribution ?? []} />
+      </div>
+      <RecentRatingsSection ratings={dashboardData?.recentRatings ?? []} totalCount={totalFeedbackCount} />
+      <RecentFeedbackSection feedback={dashboardData?.recentFeedback ?? []} totalCount={totalFeedbackCount} />
+    </main>
+  );
+}

--- a/syncback/app/(dashboard)/dashboard/page.tsx
+++ b/syncback/app/(dashboard)/dashboard/page.tsx
@@ -1,17 +1,13 @@
 import { currentUser } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 
-import { PerformanceOverviewSection } from "./sections/PerformanceOverviewSection";
-import { RatingDistributionSection } from "./sections/RatingDistributionSection";
-import { RatingTrendSection } from "./sections/RatingTrendSection";
-import { RecentFeedbackSection } from "./sections/RecentFeedbackSection";
-import { RecentRatingsSection } from "./sections/RecentRatingsSection";
 import { HeaderMegaMenu } from "@/components/navigation/HeaderMegaMenu";
 import { PageBackground } from "@/components/shared/PageBackground";
 import { api } from "@/convex/_generated/api";
 import { getConvexClient } from "@/lib/convexClient";
 
 import { resolveAppUrl } from "../settings/actions";
+import { DashboardContent } from "./DashboardContent";
 
 export default async function DashboardPage() {
   const user = await currentUser();
@@ -61,25 +57,11 @@ export default async function DashboardPage() {
         <div className="absolute left-[10%] bottom-[18%] h-64 w-64 rounded-full bg-[radial-gradient(circle_at_center,_rgba(16,185,129,0.28),_rgba(255,255,255,0))] blur-3xl" />
       </PageBackground>
 
-      <main className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-6 pb-24 pt-20 sm:px-8 lg:px-12">
-        <PerformanceOverviewSection
-          businessName={businessName}
-          metrics={dashboardData?.metrics ?? []}
-          hasConvexError={hasConvexError}
-        />
-        <div className="grid gap-10 lg:grid-cols-2">
-          <RatingTrendSection data={dashboardData?.ratingTrend ?? []} />
-          <RatingDistributionSection data={dashboardData?.ratingDistribution ?? []} />
-        </div>
-        <RecentRatingsSection
-          ratings={dashboardData?.recentRatings ?? []}
-          totalCount={dashboardData?.totalFeedbackCount ?? 0}
-        />
-        <RecentFeedbackSection
-          feedback={dashboardData?.recentFeedback ?? []}
-          totalCount={dashboardData?.totalFeedbackCount ?? 0}
-        />
-      </main>
+      <DashboardContent
+        initialBusinessName={businessName}
+        initialDashboardData={dashboardData}
+        initialHasConvexError={hasConvexError}
+      />
     </div>
   );
 }

--- a/syncback/app/(dashboard)/dashboard/sections/PerformanceOverviewSection.tsx
+++ b/syncback/app/(dashboard)/dashboard/sections/PerformanceOverviewSection.tsx
@@ -1,27 +1,103 @@
+"use client";
+
+import { useMemo } from "react";
+
 import type { StatsGridProps } from "./types";
 import { StatsGrid } from "@/components/dashboard/StatsGrid";
 import SplitText from "@/components/shared/SplitText";
+import { IconRefresh } from "@tabler/icons-react";
+import clsx from "clsx";
 
 export type PerformanceOverviewSectionProps = {
   businessName: string;
   metrics: StatsGridProps["metrics"];
   hasConvexError?: boolean;
+  onReload?: () => void;
+  isReloading?: boolean;
+  lastUpdatedAt?: number | null;
+  autoRefreshIntervalMs?: number;
 };
 
-export function PerformanceOverviewSection({ businessName, metrics, hasConvexError = false }: PerformanceOverviewSectionProps) {
+export function PerformanceOverviewSection({
+  businessName,
+  metrics,
+  hasConvexError = false,
+  onReload,
+  isReloading = false,
+  lastUpdatedAt = null,
+  autoRefreshIntervalMs,
+}: PerformanceOverviewSectionProps) {
+  const lastUpdatedLabel = useMemo(() => {
+    if (!lastUpdatedAt) {
+      return null;
+    }
+
+    try {
+      const formatter = new Intl.DateTimeFormat(undefined, {
+        hour: "numeric",
+        minute: "2-digit",
+      });
+      return formatter.format(new Date(lastUpdatedAt));
+    } catch {
+      return new Date(lastUpdatedAt).toLocaleTimeString();
+    }
+  }, [lastUpdatedAt]);
+
+  const autoRefreshLabel = useMemo(() => {
+    if (!autoRefreshIntervalMs) {
+      return null;
+    }
+
+    const minutes = Math.round(autoRefreshIntervalMs / 60000);
+
+    if (minutes % 60 === 0) {
+      const hours = minutes / 60;
+      return hours === 1 ? "hour" : `${hours} hours`;
+    }
+
+    return minutes === 1 ? "minute" : `${minutes} minutes`;
+  }, [autoRefreshIntervalMs]);
+
   return (
     <section className="space-y-6">
-      <div className="space-y-2">
-        <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">Performance overview</p>
-        <SplitText
-          text={`Insights for ${businessName}`}
-          tag="h1"
-          textAlign="left"
-          className="text-3xl font-semibold leading-tight text-slate-950 dark:text-slate-100 sm:text-4xl lg:text-5xl"
-        />
-        <p className="max-w-2xl text-base text-slate-600 dark:text-slate-300 sm:text-lg">
-          Track how guests feel about every experience and spot momentum in your ratings at a glance.
-        </p>
+      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div className="space-y-2">
+          <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">Performance overview</p>
+          <SplitText
+            text={`Insights for ${businessName}`}
+            tag="h1"
+            textAlign="left"
+            className="text-3xl font-semibold leading-tight text-slate-950 dark:text-slate-100 sm:text-4xl lg:text-5xl"
+          />
+          <p className="max-w-2xl text-base text-slate-600 dark:text-slate-300 sm:text-lg">
+            Track how guests feel about every experience and spot momentum in your ratings at a glance.
+          </p>
+        </div>
+
+        {onReload ? (
+          <div className="flex flex-col items-start gap-2 text-left text-xs text-slate-500 md:items-end md:text-right dark:text-slate-400">
+            {lastUpdatedLabel ? (
+              <p aria-live="polite" className="text-xs">
+                Last updated {lastUpdatedLabel}
+                {autoRefreshLabel ? ` · Auto refreshes every ${autoRefreshLabel}` : ""}
+              </p>
+            ) : autoRefreshLabel ? (
+              <p className="text-xs">Auto refreshes every {autoRefreshLabel}</p>
+            ) : null}
+            <button
+              type="button"
+              onClick={onReload}
+              className={clsx(
+                "inline-flex items-center gap-2 rounded-full border border-slate-900/10 bg-white/80 px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-900/30 focus-visible:ring-offset-2 hover:bg-white disabled:cursor-not-allowed disabled:opacity-70",
+                "dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-100 dark:hover:bg-slate-900",
+              )}
+              disabled={isReloading}
+            >
+              <IconRefresh className={clsx("h-4 w-4", isReloading && "animate-spin")} stroke={1.5} />
+              {isReloading ? "Refreshing" : "Reload data"}
+            </button>
+          </div>
+        ) : null}
       </div>
       {hasConvexError ? (
         <div

--- a/syncback/app/api/dashboard/data/route.ts
+++ b/syncback/app/api/dashboard/data/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { currentUser } from "@clerk/nextjs/server";
+
+import { api } from "@/convex/_generated/api";
+import { getConvexClient } from "@/lib/convexClient";
+
+import { resolveAppUrl } from "../../../(dashboard)/settings/actions";
+
+export async function GET() {
+  const user = await currentUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const convex = getConvexClient();
+  const appUrl = await resolveAppUrl();
+
+  let hasConvexError = false;
+
+  let business: Awaited<ReturnType<typeof convex.query>> | null = null;
+
+  try {
+    business = await convex.query(api.businesses.forClerkUser, {
+      clerkUserId: user.id,
+      appUrl,
+    });
+  } catch (error) {
+    hasConvexError = true;
+    console.error("Failed to load business for dashboard API", error);
+  }
+
+  let dashboardData: Awaited<ReturnType<typeof convex.query>> | null = null;
+
+  if (business) {
+    try {
+      dashboardData = await convex.query(api.feedbacks.dashboardData, {
+        businessId: business._id,
+      });
+    } catch (error) {
+      hasConvexError = true;
+      console.error("Failed to load dashboard data via API", error);
+    }
+  }
+
+  const businessName = business?.name ?? "Your business";
+
+  return NextResponse.json({
+    businessName,
+    dashboardData,
+    hasConvexError,
+  });
+}


### PR DESCRIPTION
## Summary
- add a client-side dashboard container that polls metrics hourly and allows manual reloads
- expose an authenticated API endpoint for fetching dashboard metrics
- enhance the performance overview header with status messaging and a reload control

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6d176fba8832b8dd967dc3355ccb4